### PR TITLE
make run_cron actually run the action

### DIFF
--- a/wp-crontrol.php
+++ b/wp-crontrol.php
@@ -285,9 +285,7 @@ class Crontrol {
 		foreach ( $crons as $time => $cron ) {
 			if ( isset( $cron[ $hookname ][ $sig ] ) ) {
 				$args = $cron[ $hookname ][ $sig ]['args'];
-				delete_transient( 'doing_cron' );
-				wp_schedule_single_event( time() - 1, $hookname, $args );
-				spawn_cron();
+				do_action( $hookname, $args );
 				return true;
 			}
 		}


### PR DESCRIPTION
wp_schedule_single_event is great but sometimes fails, when you really
want to run the CRON it’s best to run the action itself