### PR TITLE
 Several bug fixes, new classes and some PHPDoc work

### DIFF
--- a/wp-crontrol.php
+++ b/wp-crontrol.php
@@ -459,7 +459,7 @@ class Crontrol {
 				$args = $cron[ $hookname ][ $sig ]['args'];
 				delete_transient( 'doing_cron' );
 				if ( $this->_okay_to_schedule() ) {
-				wp_schedule_single_event( time() - 1, $hookname, $args );
+					wp_schedule_single_event( time() - 1, $hookname, $args );
 				}
 				spawn_cron();
 				return true;

--- a/wp-crontrol.php
+++ b/wp-crontrol.php
@@ -64,7 +64,7 @@ class Control_Base {
  * Class Control_Request
  */
 class Control_Request extends Control_Base {
-	/**
+
 	/**
 	 * @var string $schedule
 	 */

--- a/wp-crontrol.php
+++ b/wp-crontrol.php
@@ -52,7 +52,7 @@ class Control_Base {
 	 * @param array $args
 	 */
 	public function __construct( $args = array() ) {
-		foreach( $args as $name => $value ) {
+		foreach ( $args as $name => $value ) {
 			if ( property_exists( $this, $name ) ) {
 				$this->$name = $value;
 			}
@@ -131,37 +131,38 @@ class Control_Request extends Control_Base {
  */
 class Control_Event extends Control_Base {
 
-    /**
+	/**
 	 * @var string
 	 */
-    public $hook;
+	public $hook;
 
-    /**
+	/**
 	 * @var string
 	 */
-    public $time;
+	public $time;
 
-    /**
+	/**
 	 * @var string
 	 */
-    public $sig;
+	public $sig;
 
-    /**
+	/**
 	 * @var array
 	 */
-    public $args;
+	public $args;
 
-    /**
+	/**
 	 * @var string
 	 */
-    public $schedule = false;
+	public $schedule = false;
 
-    /**
+	/**
 	 * @var string
 	 */
-    public $interval;
+	public $interval;
 
 }
+
 class Crontrol {
 
 	/**
@@ -448,7 +449,8 @@ class Crontrol {
 	 * Executes an event by scheduling a new single event with the same arguments.
 	 *
 	 * @param string $hookname The hookname of the cron event to run
-     * @return bool
+	 *
+	 * @return bool
 	 */
 	public function run_cron( $hookname, $sig ) {
 		$crons = _get_cron_array();
@@ -456,7 +458,7 @@ class Crontrol {
 			if ( isset( $cron[ $hookname ][ $sig ] ) ) {
 				$args = $cron[ $hookname ][ $sig ]['args'];
 				delete_transient( 'doing_cron' );
-                if ( $this->_okay_to_schedule() ) {
+				if ( $this->_okay_to_schedule() ) {
 				wp_schedule_single_event( time() - 1, $hookname, $args );
 				}
 				spawn_cron();
@@ -467,18 +469,18 @@ class Crontrol {
 	}
 
 	/**
-     * Do not schedule event when both:
-     *
+	 * Do not schedule event when both:
+	 *
 	 *      1. DISABLE_WP_CRON is true because wp_cron() will not
 	 *         have consumed the previously scheduled event, and
 	 *
 	 *      2. $_GET[ 'doing_wp_cron' ] is set because spawn_cron()
 	 *         will just return and not consume this event.
-     *
+	 *
 	 */
 	private function _okay_to_schedule() {
-        return ! ( defined( 'DISABLE_WP_CRON' ) && DISABLE_WP_CRON
-           && isset( $_GET[ 'doing_wp_cron' ] ) );
+		return ! ( defined( 'DISABLE_WP_CRON' ) && DISABLE_WP_CRON
+		           && isset( $_GET[ 'doing_wp_cron' ] ) );
 	}
 	/**
 	 * Adds a new cron event.
@@ -510,7 +512,8 @@ class Crontrol {
 	 * Deletes a cron event.
 	 *
 	 * @param string $name The hookname of the event to delete.
-     * @return bool
+	 *
+	 * @return bool
 	 */
 	public function delete_cron( $to_delete, $sig, $next_run ) {
 		$crons = _get_cron_array();
@@ -574,11 +577,11 @@ class Crontrol {
 	}
 
 	/**
-     * Add links for this plugin on the plugin page
-     *\
-	 * @param array $actions
+	 * Add links for this plugin on the plugin page
+	 *
+	 * @param array  $actions
 	 * @param string $plugin_file
-	 * @param array $plugin_data
+	 * @param array  $plugin_data
 	 * @param string $context
 	 *
 	 * @return mixed
@@ -1079,8 +1082,8 @@ class Crontrol {
 	}
 
 	/**
-     * Returns an array Control_Event objects
-     *
+	 * Returns an array Control_Event objects
+	 *
 	 * @return Control_Event[]|WP_Error
 	 */
 	public function get_cron_events() {
@@ -1099,15 +1102,15 @@ class Crontrol {
 			foreach ( $cron as $hook => $dings ) {
 				foreach ( $dings as $sig => $data ) {
 
-					$event = new Control_Event();
+					$event           = new Control_Event();
 					$event->hook     = $hook;
 					$event->time     = $time;
 					$event->sig      = $sig;
-					$event->args     = $data['args'];
-					$event->schedule = $data['schedule'];
-					$event->interval = isset( $data['interval'] )
-                        ? $data['interval']
-                        : null;
+					$event->args     = $data[ 'args' ];
+					$event->schedule = $data[ 'schedule' ];
+					$event->interval = isset( $data[ 'interval' ] )
+						? $data[ 'interval' ]
+						: null;
 					$events[ "$hook-$sig-$time" ] = $event;
 
 				}


### PR DESCRIPTION
I was having trouble with cron so installed WP Control. But when I opened the code in PhpStorm it showed a lot of _"potentially undefined variables"_. Being the obsessive compulsive I am I dove in and and started cleaning them up. And as I worked with the plugin on a client site I found two edge-case bugs, diagnosed them and added fixes.  

Here is the list of changes and thus what this pull request includes:

1. Added @return values where appropriate to PHPDoc for methods, and added basic PHPDoc for methods where there was none.

2. Replaced use of `extract()` with a `Control_Request` class so that both PhpStorm and the coder could explicitly see the elements expected and used from `$_POST`.

3. Added a `Control_Event` class per one of your comments to replace the stdClass object cast from the associative array.

4. Found that _"Run Now"_ does not remove the non-repeating event it adds when `DISABLE_WP_CRON` is set even though it will run it, so added a fix for this.

5. Wrapped `<form>` actions with `esc_url(admin_url())` because not doing so causes the plugin to break for these forms when used with a client's URL proxy configuration and a supporting custom plugin that needs to control all URLs. 

6. Used `===` instead of `==` and `!==` instead of `!=` in your embedded Javascript because PhpStorm wanted me doing doing so can cause unexpected errors.

7. Got rid of the variable `$i` that PhpStorm flagged as unused.