### PR TITLE
Update core hooks

### DIFF
--- a/wp-crontrol.php
+++ b/wp-crontrol.php
@@ -1046,6 +1046,7 @@ class Crontrol {
 			'wp_scheduled_auto_draft_delete',
 			'update_network_counts',
 			'delete_expired_transients',
+			'wp_privacy_delete_old_export_files',
 		);
 
 		$this->show_cron_status();

--- a/wp-crontrol.php
+++ b/wp-crontrol.php
@@ -1047,6 +1047,7 @@ class Crontrol {
 			'update_network_counts',
 			'delete_expired_transients',
 			'wp_privacy_delete_old_export_files',
+			'recovery_mode_clean_expired_keys',
 		);
 
 		$this->show_cron_status();


### PR DESCRIPTION
This PR adds a hook `wp_privacy_delete_old_export_files` introduced in Wordpress 4.9.6 to the core_hooks. It also adds the `recovery_mode_clean_expired_keys` (introduced in Wordpress 5.2) to the list of core hooks.