### PR TITLE
Fix the adding of new cron events when `DISALLOW_FILE_EDIT` is true

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wp-crontrol",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "description": "WP Crontrol lets you view and control what's happening in the WP-Cron system.",
   "license": "GPL-2.0-or-later",
   "private": true,

--- a/readme.md
+++ b/readme.md
@@ -4,7 +4,7 @@ Contributors: johnbillion, scompt
 Tags: cron, wp-cron, crontrol, debug  
 Requires at least: 4.1  
 Tested up to: 5.6  
-Stable tag: 1.9.0  
+Stable tag: 1.9.1  
 Requires PHP: 5.3  
 Donate link: https://github.com/sponsors/johnbillion
 

--- a/wp-crontrol.php
+++ b/wp-crontrol.php
@@ -5,7 +5,7 @@
  * Description:  WP Crontrol enables you to view and control what's happening in the WP-Cron system.
  * Author:       John Blackbourn & crontributors
  * Author URI:   https://github.com/johnbillion/wp-crontrol/graphs/contributors
- * Version:      1.9.0
+ * Version:      1.9.1
  * Text Domain:  wp-crontrol
  * Domain Path:  /languages/
  * Requires PHP: 5.3.6

--- a/wp-crontrol.php
+++ b/wp-crontrol.php
@@ -1080,6 +1080,10 @@ function show_cron_form( $editing ) {
 						</td>
 					</tr>
 					<?php
+				} else {
+					?>
+					<input type="hidden" name="action" value="new_cron"/>
+					<?php
 				}
 
 				if ( $is_editing_php || $can_add_php ) {

--- a/wp-crontrol.php
+++ b/wp-crontrol.php
@@ -26,7 +26,7 @@
  *
  * @package    wp-crontrol
  * @author     John Blackbourn <john@johnblackbourn.com> & Edward Dale <scompt@scompt.com>
- * @copyright  Copyright 2008 Edward Dale, 2012-2020 John Blackbourn
+ * @copyright  Copyright 2008 Edward Dale, 2012-2021 John Blackbourn
  * @license    http://www.gnu.org/licenses/gpl.txt GPL 2.0
  * @link       https://wordpress.org/plugins/wp-crontrol/
  * @since      0.2


### PR DESCRIPTION
Ref: https://wordpress.org/support/topic/unable-to-save-custom-event/