### PR TITLE
Pause and resume

### DIFF
--- a/css/wp-crontrol.css
+++ b/css/wp-crontrol.css
@@ -86,6 +86,18 @@ table.wp-list-table {
 	color: #d63638;
 }
 
+.status-crontrol-paused .dashicons {
+	background: #646970;
+	border-radius: 50%;
+	color: #fff;
+	font-size: 14px;
+	height: 14px;
+	line-height: 14px;
+	margin-top: 2px;
+	padding: 1px;
+	width: 14px;
+}
+
 .wp-list-table .column-crontrol_https,
 .wp-list-table .column-crontrol_queries,
 .wp-list-table .column-crontrol_time {

--- a/css/wp-crontrol.css
+++ b/css/wp-crontrol.css
@@ -49,6 +49,10 @@ table.wp-list-table {
 	border-color: #d63638;
 }
 
+.wp-list-table tr.crontrol-paused th {
+	border-color: #8c8f94;
+}
+
 .wp-list-table .column-crontrol_icon .dashicons,
 .wp-list-table .check-column .dashicons {
 	margin-left: 6px;

--- a/css/wp-crontrol.css
+++ b/css/wp-crontrol.css
@@ -53,6 +53,10 @@ table.wp-list-table {
 	border-color: #8c8f94;
 }
 
+.wp-list-table tr.crontrol-paused:not(.crontrol-no-action) .column-crontrol_actions {
+	text-decoration: line-through;
+}
+
 .wp-list-table .column-crontrol_icon .dashicons,
 .wp-list-table .check-column .dashicons {
 	margin-left: 6px;

--- a/readme.md
+++ b/readme.md
@@ -15,7 +15,7 @@ WP Crontrol enables you to view and control what's happening in the WP-Cron syst
 WP Crontrol enables you to view and control what's happening in the WP-Cron system. From the admin screens you can:
 
  * View all cron events along with their arguments, recurrence, callback functions, and when they are next due.
- * Edit, delete, and immediately run any cron events.
+ * Edit, delete, pause, resume, and immediately run cron events.
  * Add new cron events.
  * Bulk delete cron events.
  * Add and remove custom cron schedules.
@@ -51,7 +51,7 @@ Yes, it's actively tested and working up to PHP 8.1.
 
 ### Why do some cron events reappear shortly after I delete them?
 
-If the event is added by a plugin then the plugin most likely rescheduled the event as soon as it saw that the event was missing. Unfortunately there's nothing that WP Crontrol can do about this - you should contact the author of the related plugin and ask for advice.
+If the event is added by a plugin then the plugin most likely rescheduled the event as soon as it saw that the event was missing. To get around this you can instead use the "Pause" option for the event which means it'll remain in place but won't perform any action when it runs.
 
 ### Is it safe to delete cron events?
 
@@ -62,6 +62,18 @@ If the event shows "None" as its action then it's usually safe to delete. Please
 ### Why can't I delete some cron events?
 
 The WordPress core software uses cron events for some of its functionality and removing these events is not possible because WordPress would immediately reschedule them if you did delete them. For this reason, WP Crontrol doesn't let you delete these persistent events from WordPress core in the first place.
+
+If you don't want these events to run, you can "Pause" them instead.
+
+### What happens when I pause an event?
+
+Pausing an event will disable all actions attached to the event's hook. The event itself will remain in place and will run according to its schedule, but all actions attached to its hook will be disabled. This renders the event inoperative but keeps it scheduled so as to remain fully compatible with plugins which automatically schedule events when they're missing.
+
+As pausing an event actually pauses its hook, all events that use the same hook will be paused or resumed when pausing and resuming an event. This is much more useful and reliable than pausing individual events separately.
+
+### What happens when I resume an event?
+
+Resuming an event re-enables all actions attached to the event's hook. All events that use the same hook will be resumed.
 
 ### What does it mean when "None" is shown for the Action of a cron event?
 

--- a/readme.md
+++ b/readme.md
@@ -67,7 +67,7 @@ If you don't want these events to run, you can "Pause" them instead.
 
 ### What happens when I pause an event?
 
-Pausing an event will disable all actions attached to the event's hook. The event itself will remain in place and will run according to its schedule, but all actions attached to its hook will be disabled. This renders the event inoperative but keeps it scheduled so as to remain fully compatible with plugins which automatically schedule events when they're missing.
+Pausing an event will disable all actions attached to the event's hook. The event itself will remain in place and will run according to its schedule, but all actions attached to its hook will be disabled. This renders the event inoperative but keeps it scheduled so as to remain fully compatible with events which would otherwise get automatically rescheduled when they're missing.
 
 As pausing an event actually pauses its hook, all events that use the same hook will be paused or resumed when pausing and resuming an event. This is much more useful and reliable than pausing individual events separately.
 

--- a/src/event-list-table.php
+++ b/src/event-list-table.php
@@ -369,17 +369,18 @@ class Table extends \WP_List_Table {
 			$links[] = "<a href='" . esc_url( $link ) . "'>" . esc_html__( 'Edit', 'wp-crontrol' ) . '</a>';
 		}
 
-		$link = array(
-			'page'                  => 'crontrol_admin_manage_page',
-			'crontrol_action'       => 'run-cron',
-			'crontrol_id'           => rawurlencode( $event->hook ),
-			'crontrol_sig'          => rawurlencode( $event->sig ),
-			'crontrol_next_run_utc' => rawurlencode( $event->time ),
-		);
-		$link = add_query_arg( $link, admin_url( 'tools.php' ) );
-		$link = wp_nonce_url( $link, "crontrol-run-cron_{$event->hook}_{$event->sig}" );
+		if ( ! is_paused( $event ) ) {
+			$link = array(
+				'page'                  => 'crontrol_admin_manage_page',
+				'crontrol_action'       => 'run-cron',
+				'crontrol_id'           => rawurlencode( $event->hook ),
+				'crontrol_sig'          => rawurlencode( $event->sig ),
+				'crontrol_next_run_utc' => rawurlencode( $event->timestamp ),
+			);
+			$link = add_query_arg( $link, admin_url( 'tools.php' ) );
+			$link = wp_nonce_url( $link, "crontrol-run-cron_{$event->hook}_{$event->sig}" );
 
-		$links[] = "<a href='" . esc_url( $link ) . "'>" . esc_html__( 'Run Now', 'wp-crontrol' ) . '</a>';
+			$links[] = "<a href='" . esc_url( $link ) . "'>" . esc_html__( 'Run Now', 'wp-crontrol' ) . '</a>';
 		}
 
 		if ( is_paused( $event ) ) {

--- a/src/event-list-table.php
+++ b/src/event-list-table.php
@@ -375,7 +375,7 @@ class Table extends \WP_List_Table {
 				'crontrol_action'       => 'run-cron',
 				'crontrol_id'           => rawurlencode( $event->hook ),
 				'crontrol_sig'          => rawurlencode( $event->sig ),
-				'crontrol_next_run_utc' => rawurlencode( $event->timestamp ),
+				'crontrol_next_run_utc' => rawurlencode( $event->time ),
 			);
 			$link = add_query_arg( $link, admin_url( 'tools.php' ) );
 			$link = wp_nonce_url( $link, "crontrol-run-cron_{$event->hook}_{$event->sig}" );

--- a/src/event-list-table.php
+++ b/src/event-list-table.php
@@ -314,7 +314,7 @@ class Table extends \WP_List_Table {
 		$callbacks = \Crontrol\get_hook_callbacks( $event->hook );
 
 		if ( ! $callbacks ) {
-			$classes[] = 'crontrol-warning';
+			$classes[] = 'crontrol-no-action';
 		} else {
 			foreach ( $callbacks as $callback ) {
 				if ( ! empty( $callback['callback']['error'] ) ) {

--- a/src/event-list-table.php
+++ b/src/event-list-table.php
@@ -136,6 +136,14 @@ class Table extends \WP_List_Table {
 			return ( ! in_array( $event->hook, $all_core_hooks, true ) );
 		} );
 
+		$paused = array_filter( $events, function( $event ) {
+			return ( is_paused( $event ) );
+		} );
+
+		if ( count( $paused ) > 0 ) {
+			$filtered['paused'] = $paused;
+		}
+
 		/**
 		 * Filters the available filtered events on the cron event listing screen.
 		 *
@@ -222,6 +230,7 @@ class Table extends \WP_List_Table {
 			'noaction' => __( 'Events with no action', 'wp-crontrol' ),
 			'core'     => __( 'WordPress core events', 'wp-crontrol' ),
 			'custom'   => __( 'Custom events', 'wp-crontrol' ),
+			'paused'   => __( 'Paused events', 'wp-crontrol' ),
 		);
 
 		/**

--- a/tests/_support/AcceptanceTester.php
+++ b/tests/_support/AcceptanceTester.php
@@ -3,6 +3,8 @@
  * Acceptance testing actor.
  */
 
+use Codeception\Util\Locator;
+
 /**
  * Inherited Methods
  *
@@ -79,5 +81,21 @@ class AcceptanceTester extends \Codeception\Actor {
 	 */
 	public function amOnCronEventListingPage() {
 		return $this->amOnAdminPage( 'tools.php?page=crontrol_admin_manage_page' );
+	}
+
+	/**
+	 * Create a cron event to work with.
+	 *
+	 * @param string $hook_name The event hook name.
+	 * @return string
+	 */
+	public function amWorkingWithACronEvent( string $hook_name ) {
+		$this->amOnCronEventListingPage();
+		$this->click( 'Add New', '#wpbody' );
+		$this->fillField( 'Hook Name', $hook_name );
+		$this->selectOption( 'input[name="crontrol_next_run_date_local"]', 'Tomorrow' );
+		$this->click( 'Add Event' );
+
+		return Locator::contains( '.crontrol-events tr', $hook_name );
 	}
 }

--- a/tests/acceptance.suite.yml
+++ b/tests/acceptance.suite.yml
@@ -16,7 +16,7 @@ modules:
       browser: chrome
       host: localhost
       port: '%TEST_SITE_WEBDRIVER_PORT%'
-      window_size: 1024x768
+      window_size: 1440x900
       capabilities:
         chromeOptions:
           args: ["--headless", "--disable-gpu", "--proxy-server='direct://'", "--proxy-bypass-list=*"]

--- a/tests/acceptance/PauseEventCest.php
+++ b/tests/acceptance/PauseEventCest.php
@@ -16,5 +16,12 @@ class PauseEventCest {
 
 		$I->click( 'Pause', $row );
 		$I->seeAdminSuccessNotice( 'Paused the pause_me_soon hook.' );
+		$I->see( 'Paused', $row );
+
+		$I->click( 'Paused events (1)' );
+		$I->see( 'Paused', $row );
+
+		$I->click( 'Resume', $row );
+		$I->seeAdminSuccessNotice( 'Resumed the pause_me_soon hook.' );
 	}
 }

--- a/tests/acceptance/PauseEventCest.php
+++ b/tests/acceptance/PauseEventCest.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * Acceptance tests for pausing and resuming cron events.
+ */
+
+/**
+ * Test class.
+ */
+class PauseEventCest {
+	public function _before( AcceptanceTester $I ) {
+		$I->loginAsAdmin();
+	}
+
+	public function PausingAnEvent( AcceptanceTester $I ) {
+		$row = $I->amWorkingWithACronEvent( 'pause_me_soon' );
+
+		$I->click( 'Pause', $row );
+		$I->seeAdminSuccessNotice( 'Paused the pause_me_soon hook.' );
+	}
+}

--- a/tests/wp-config.php
+++ b/tests/wp-config.php
@@ -5,6 +5,20 @@
 
 mysqli_report( MYSQLI_REPORT_OFF );
 
+// Force the wp-admin area to use 'mobile' mode so list table row actions are shown.
+$GLOBALS['wp_filter'] = array(
+	'admin_body_class' => array(
+		10 => array(
+			array(
+				'accepted_args' => 1,
+				'function' => function( $classes ) {
+					return $classes .= ' mobile';
+				},
+			),
+		),
+	),
+);
+
 define( 'WP_DEBUG', ! empty( getenv( 'WORDPRESS_DEBUG' ) ) );
 
 // Prevent WP-Cron doing its thing during testing.


### PR DESCRIPTION
This introduces the ability to pause and resume events.

Pausing an event will disable all actions attached to the event's hook. The event itself will remain in place and will run according to its schedule, but all actions attached to its hook will be disabled. This renders the event inoperative but keeps it scheduled so as to remain fully compatible with plugins which automatically schedule events when they're missing.