### PR TITLE
Avoid additional SQL query on option wp_crontrol_paused

### DIFF
--- a/src/bootstrap.php
+++ b/src/bootstrap.php
@@ -95,12 +95,15 @@ function action_init() {
 	load_plugin_textdomain( 'wp-crontrol', false, dirname( plugin_basename( PLUGIN_FILE ) ) . '/languages' );
 
 	/** @var array<string, true>|false $paused */
-	$paused = get_option( PAUSED_OPTION, array() );
+	$paused = get_option( PAUSED_OPTION );
 
-	if ( is_array( $paused ) ) {
-		foreach ( $paused as $hook => $value ) {
-			add_action( $hook, __NAMESPACE__ . '\\pauser', -99999 );
-		}
+	if ( ! is_array( $paused ) ) {
+		$paused = array();
+		update_option( PAUSED_OPTION, $paused, true );
+	}
+
+	foreach ( $paused as $hook => $value ) {
+		add_action( $hook, __NAMESPACE__ . '\\pauser', -99999 );
 	}
 }
 

--- a/src/event.php
+++ b/src/event.php
@@ -261,7 +261,7 @@ function pause( $hook ) {
 
 	$paused[ $hook ] = true;
 
-	$result = update_option( PAUSED_OPTION, $paused, false );
+	$result = update_option( PAUSED_OPTION, $paused, true );
 
 	if ( false === $result ) {
 		return new WP_Error(
@@ -292,11 +292,7 @@ function resume( $hook ) {
 
 	unset( $paused[ $hook ] );
 
-	if ( count( $paused ) === 0 ) {
-		$result = delete_option( PAUSED_OPTION );
-	} else {
-		$result = update_option( PAUSED_OPTION, $paused, false );
-	}
+	$result = update_option( PAUSED_OPTION, $paused, true );
 
 	if ( false === $result ) {
 		return new WP_Error(


### PR DESCRIPTION
Hello John,

Ability to pause / resume events is nice, but it produces an additional (dispensable) SQL query on every page : 

```
SELECT option_value
FROM wp_options
WHERE option_name = 'wp_crontrol_paused'
LIMIT 1
```

I suggest we change a few lines of code, in order to :
- Use the autoload mechanism of core wp_options table
- Insert the option when not existing (to ensure it is always auto-loaded)
- Keep it in database, even when it's an empty array (to ensure it is always auto-loaded)

Bests regards,
Pierre