### PR TITLE
Remove a global from wp-crontrol.php

### DIFF
--- a/wp-crontrol.php
+++ b/wp-crontrol.php
@@ -43,13 +43,11 @@ if ( ! version_compare( PHP_VERSION, '5.6', '>=' ) ) {
 	return;
 }
 
-$autoload = __DIR__ . '/vendor/autoload.php';
-
-if ( ! file_exists( $autoload ) ) {
+if ( ! file_exists( __DIR__ . '/vendor/autoload.php' ) ) {
 	return;
 }
 
-require_once $autoload;
+require_once __DIR__ . '/vendor/autoload.php';
 require_once __DIR__ . '/src/bootstrap.php';
 require_once __DIR__ . '/src/event.php';
 require_once __DIR__ . '/src/schedule.php';


### PR DESCRIPTION
Core has enough globals.