### PR TITLE
Cast (int) $event->timestamp - time() to fix string - int error

### DIFF
--- a/src/event.php
+++ b/src/event.php
@@ -450,7 +450,7 @@ function is_too_frequent( stdClass $event ) {
  * @return bool Whether the event is late.
  */
 function is_late( stdClass $event ) {
-	$until = $event->timestamp - time();
+	$until = (int) $event->timestamp - time();
 
 	return ( $until < ( 0 - ( 10 * MINUTE_IN_SECONDS ) ) );
 }


### PR DESCRIPTION
On line 453 of wp-crontrol/src/event.php, $event->timestamp - time() is not automatically cast by PHP version 8.1.2 from the String $event->timestamp - time() to an integer to perform the arithmetic. Forcing the cast with (int) $event->timestamp - time() corrects the critical error, detailed below, that prevented the Cron Event dashboard from loading.

2023-04-28T18:12:38+00:00 CRITICAL Uncaught TypeError: Unsupported operand types: string - int in /var/www/toddlahman.com/wp-content/plugins/wp-crontrol/src/event.php:453 Stack trace:
#0 [internal function]: Crontrol\Event\is_late()
#1 /var/www/toddlahman.com/wp-content/plugins/wp-crontrol/src/event-list-table.php(93): array_map() #2 /var/www/toddlahman.com/wp-content/plugins/wp-crontrol/src/event.php(484): Crontrol\Event\Table->prepare_items() #3 /var/www/toddlahman.com/wp-content/plugins/wp-crontrol/src/bootstrap.php(2057): Crontrol\Event\get_list_table() #4 /var/www/toddlahman.com/wp-includes/class-wp-hook.php(308): Crontrol\setup_manage_page() #5 /var/www/toddlahman.com/wp-includes/class-wp-hook.php(332): WP_Hook->apply_filters() #6 /var/www/toddlahman.com/wp-includes/plugin.php(517): WP_Hook->do_action() #7 /var/www/toddlahman.com/wp-admin/admin.php(237): do_action() #8 /var/www/toddlahman.com/wp-admin/tools.php(40): require_once('...') #9 {main}
  thrown in /var/www/toddlahman.com/wp-content/plugins/wp-crontrol/src/event.php on line 453