### PR TITLE
Fix exports

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,12 +1,10 @@
 * text=auto
 
 # Directories
-/.git export-ignore
-/.github export-ignore
-/.wordpress-org export-ignore
-/bin export-ignore
-/node_modules export-ignore
-/tests export-ignore
+/.github/ export-ignore
+/.wordpress-org/ export-ignore linguist-documentation
+/bin/ export-ignore
+/tests/ export-ignore
 
 # Files
 /.gitattributes export-ignore
@@ -14,10 +12,8 @@
 /.gitignore export-ignore
 /CODE_OF_CONDUCT.md export-ignore
 /codeception.dist.yml export-ignore
-/composer.lock export-ignore
 /CONTRIBUTING.md export-ignore
 /docker-compose.yml export-ignore
-/package-lock.json export-ignore
 /package.json export-ignore
 /phpcs.xml.dist export-ignore
 /phpcs53.xml export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,10 @@
-/build
-/node_modules
-/vendor/*
+/build/
+/node_modules/
+/vendor/
 
 /composer.lock
 /package-lock.json
 /tests/_output/
-/tests/_support/_generated
-/tests/cache
-/tests/wordpress
+/tests/_support/_generated/
+/tests/cache/
+/tests/wordpress/


### PR DESCRIPTION
ZIP archives are created from git index, not from the filesystem.

Here is how to test.
```bash
git archive HEAD | tar --list --exclude="src" --exclude="src/*"
```
