### PR TITLE
Skip the package caches when running nightly tests

### DIFF
--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -41,3 +41,4 @@ jobs:
       node: false
       php: ${{ matrix.php }}
       wp: 'nightly'
+      cache: false


### PR DESCRIPTION
Skip the package caches when running nightly tests. This allows the latest nightly to always be used.