### PR TITLE
Speed up the Playwright installation

### DIFF
--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -58,7 +58,7 @@ jobs:
           - wp: '6.3'
             php: '7.4'
       fail-fast: false
-    uses: johnbillion/plugin-infrastructure/.github/workflows/reusable-acceptance-tests.yml@1603731e84de084b9cc0a6d65b4dfb04ce3a96a1 # v2.0.0
+    uses: johnbillion/plugin-infrastructure/.github/workflows/reusable-acceptance-tests.yml@92a2affb0fe5c6f3c1a32eaefda057a326766196 # v2.1.0-beta.1
     with:
       node: false
       php: ${{ matrix.php }}

--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -58,7 +58,7 @@ jobs:
           - wp: '6.3'
             php: '7.4'
       fail-fast: false
-    uses: johnbillion/plugin-infrastructure/.github/workflows/reusable-acceptance-tests.yml@92a2affb0fe5c6f3c1a32eaefda057a326766196 # v2.1.0-beta.1
+    uses: johnbillion/plugin-infrastructure/.github/workflows/reusable-acceptance-tests.yml@5a327134e8fabebf5fbf0e8e31c46fa4d36b0d23 # v2.1.0-beta.2
     with:
       node: false
       php: ${{ matrix.php }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
     name: Build
     permissions:
       contents: write
-    uses: johnbillion/plugin-infrastructure/.github/workflows/reusable-build.yml@1603731e84de084b9cc0a6d65b4dfb04ce3a96a1 # v2.0.0
+    uses: johnbillion/plugin-infrastructure/.github/workflows/reusable-build.yml@92a2affb0fe5c6f3c1a32eaefda057a326766196 # v2.1.0-beta.1
     with:
       node: false
       tag: ${{ github.event_name != 'workflow_dispatch' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
     name: Build
     permissions:
       contents: write
-    uses: johnbillion/plugin-infrastructure/.github/workflows/reusable-build.yml@92a2affb0fe5c6f3c1a32eaefda057a326766196 # v2.1.0-beta.1
+    uses: johnbillion/plugin-infrastructure/.github/workflows/reusable-build.yml@5a327134e8fabebf5fbf0e8e31c46fa4d36b0d23 # v2.1.0-beta.2
     with:
       node: false
       tag: ${{ github.event_name != 'workflow_dispatch' }}

--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -32,7 +32,7 @@ jobs:
     name: ${{ matrix.label }}
     permissions:
       contents: read
-    uses: johnbillion/plugin-infrastructure/.github/workflows/reusable-coding-standards.yml@92a2affb0fe5c6f3c1a32eaefda057a326766196 # v2.1.0-beta.1
+    uses: johnbillion/plugin-infrastructure/.github/workflows/reusable-coding-standards.yml@5a327134e8fabebf5fbf0e8e31c46fa4d36b0d23 # v2.1.0-beta.2
     strategy:
       matrix:
         label:

--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -32,7 +32,7 @@ jobs:
     name: ${{ matrix.label }}
     permissions:
       contents: read
-    uses: johnbillion/plugin-infrastructure/.github/workflows/reusable-coding-standards.yml@1603731e84de084b9cc0a6d65b4dfb04ce3a96a1 # v2.0.0
+    uses: johnbillion/plugin-infrastructure/.github/workflows/reusable-coding-standards.yml@92a2affb0fe5c6f3c1a32eaefda057a326766196 # v2.1.0-beta.1
     strategy:
       matrix:
         label:

--- a/.github/workflows/deploy-assets.yml
+++ b/.github/workflows/deploy-assets.yml
@@ -13,7 +13,7 @@ jobs:
     name: WordPress.org
     permissions:
       contents: read
-    uses: johnbillion/plugin-infrastructure/.github/workflows/reusable-deploy-assets.yml@92a2affb0fe5c6f3c1a32eaefda057a326766196 # v2.1.0-beta.1
+    uses: johnbillion/plugin-infrastructure/.github/workflows/reusable-deploy-assets.yml@5a327134e8fabebf5fbf0e8e31c46fa4d36b0d23 # v2.1.0-beta.2
     with:
       plugin: wp-crontrol
       readme: readme.txt

--- a/.github/workflows/deploy-assets.yml
+++ b/.github/workflows/deploy-assets.yml
@@ -13,7 +13,7 @@ jobs:
     name: WordPress.org
     permissions:
       contents: read
-    uses: johnbillion/plugin-infrastructure/.github/workflows/reusable-deploy-assets.yml@1603731e84de084b9cc0a6d65b4dfb04ce3a96a1 # v2.0.0
+    uses: johnbillion/plugin-infrastructure/.github/workflows/reusable-deploy-assets.yml@92a2affb0fe5c6f3c1a32eaefda057a326766196 # v2.1.0-beta.1
     with:
       plugin: wp-crontrol
       readme: readme.txt

--- a/.github/workflows/deploy-tag.yml
+++ b/.github/workflows/deploy-tag.yml
@@ -18,7 +18,7 @@ permissions: {}
 jobs:
   deploy:
     name: Deploy Tag
-    uses: johnbillion/plugin-infrastructure/.github/workflows/reusable-deploy-tag.yml@92a2affb0fe5c6f3c1a32eaefda057a326766196 # v2.1.0-beta.1
+    uses: johnbillion/plugin-infrastructure/.github/workflows/reusable-deploy-tag.yml@5a327134e8fabebf5fbf0e8e31c46fa4d36b0d23 # v2.1.0-beta.2
     permissions:
       contents: read
       issues: write

--- a/.github/workflows/deploy-tag.yml
+++ b/.github/workflows/deploy-tag.yml
@@ -18,7 +18,7 @@ permissions: {}
 jobs:
   deploy:
     name: Deploy Tag
-    uses: johnbillion/plugin-infrastructure/.github/workflows/reusable-deploy-tag.yml@1603731e84de084b9cc0a6d65b4dfb04ce3a96a1 # v2.0.0
+    uses: johnbillion/plugin-infrastructure/.github/workflows/reusable-deploy-tag.yml@92a2affb0fe5c6f3c1a32eaefda057a326766196 # v2.1.0-beta.1
     permissions:
       contents: read
       issues: write

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -40,7 +40,7 @@ jobs:
     name: WP ${{ matrix.wp }}
     permissions:
       contents: read
-    uses: johnbillion/plugin-infrastructure/.github/workflows/reusable-integration-tests.yml@92a2affb0fe5c6f3c1a32eaefda057a326766196 # v2.1.0-beta.1
+    uses: johnbillion/plugin-infrastructure/.github/workflows/reusable-integration-tests.yml@5a327134e8fabebf5fbf0e8e31c46fa4d36b0d23 # v2.1.0-beta.2
     strategy:
       # See the following for PHP compatibility of WordPress versions:
       # https://make.wordpress.org/core/handbook/references/php-compatibility-and-wordpress-versions/

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -40,7 +40,7 @@ jobs:
     name: WP ${{ matrix.wp }}
     permissions:
       contents: read
-    uses: johnbillion/plugin-infrastructure/.github/workflows/reusable-integration-tests.yml@1603731e84de084b9cc0a6d65b4dfb04ce3a96a1 # v2.0.0
+    uses: johnbillion/plugin-infrastructure/.github/workflows/reusable-integration-tests.yml@92a2affb0fe5c6f3c1a32eaefda057a326766196 # v2.1.0-beta.1
     strategy:
       # See the following for PHP compatibility of WordPress versions:
       # https://make.wordpress.org/core/handbook/references/php-compatibility-and-wordpress-versions/

--- a/.github/workflows/lint-workflows.yml
+++ b/.github/workflows/lint-workflows.yml
@@ -27,4 +27,4 @@ jobs:
       security-events: write
       actions: read
       contents: read
-    uses: johnbillion/plugin-infrastructure/.github/workflows/reusable-workflow-lint.yml@92a2affb0fe5c6f3c1a32eaefda057a326766196 # v2.1.0-beta.1
+    uses: johnbillion/plugin-infrastructure/.github/workflows/reusable-workflow-lint.yml@5a327134e8fabebf5fbf0e8e31c46fa4d36b0d23 # v2.1.0-beta.2

--- a/.github/workflows/lint-workflows.yml
+++ b/.github/workflows/lint-workflows.yml
@@ -27,4 +27,4 @@ jobs:
       security-events: write
       actions: read
       contents: read
-    uses: johnbillion/plugin-infrastructure/.github/workflows/reusable-workflow-lint.yml@1603731e84de084b9cc0a6d65b4dfb04ce3a96a1 # v2.0.0
+    uses: johnbillion/plugin-infrastructure/.github/workflows/reusable-workflow-lint.yml@92a2affb0fe5c6f3c1a32eaefda057a326766196 # v2.1.0-beta.1

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -37,7 +37,7 @@ jobs:
           - '8.3'
           - '7.4'
       fail-fast: false
-    uses: johnbillion/plugin-infrastructure/.github/workflows/reusable-acceptance-tests.yml@1603731e84de084b9cc0a6d65b4dfb04ce3a96a1 # v2.0.0
+    uses: johnbillion/plugin-infrastructure/.github/workflows/reusable-acceptance-tests.yml@92a2affb0fe5c6f3c1a32eaefda057a326766196 # v2.1.0-beta.1
     with:
       node: false
       php: ${{ matrix.php }}
@@ -48,7 +48,7 @@ jobs:
     name: Nightly ${{ matrix.label }}
     permissions:
       contents: read
-    uses: johnbillion/plugin-infrastructure/.github/workflows/reusable-integration-tests.yml@1603731e84de084b9cc0a6d65b4dfb04ce3a96a1 # v2.0.0
+    uses: johnbillion/plugin-infrastructure/.github/workflows/reusable-integration-tests.yml@92a2affb0fe5c6f3c1a32eaefda057a326766196 # v2.1.0-beta.1
     strategy:
       matrix:
         label:

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -37,7 +37,7 @@ jobs:
           - '8.3'
           - '7.4'
       fail-fast: false
-    uses: johnbillion/plugin-infrastructure/.github/workflows/reusable-acceptance-tests.yml@92a2affb0fe5c6f3c1a32eaefda057a326766196 # v2.1.0-beta.1
+    uses: johnbillion/plugin-infrastructure/.github/workflows/reusable-acceptance-tests.yml@5a327134e8fabebf5fbf0e8e31c46fa4d36b0d23 # v2.1.0-beta.2
     with:
       node: false
       php: ${{ matrix.php }}
@@ -48,7 +48,7 @@ jobs:
     name: Nightly ${{ matrix.label }}
     permissions:
       contents: read
-    uses: johnbillion/plugin-infrastructure/.github/workflows/reusable-integration-tests.yml@92a2affb0fe5c6f3c1a32eaefda057a326766196 # v2.1.0-beta.1
+    uses: johnbillion/plugin-infrastructure/.github/workflows/reusable-integration-tests.yml@5a327134e8fabebf5fbf0e8e31c46fa4d36b0d23 # v2.1.0-beta.2
     strategy:
       matrix:
         label:

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -28,7 +28,7 @@ jobs:
     name: ${{ matrix.label }}
     permissions:
       contents: read
-    uses: johnbillion/plugin-infrastructure/.github/workflows/reusable-static-analysis.yml@1603731e84de084b9cc0a6d65b4dfb04ce3a96a1 # v2.0.0
+    uses: johnbillion/plugin-infrastructure/.github/workflows/reusable-static-analysis.yml@92a2affb0fe5c6f3c1a32eaefda057a326766196 # v2.1.0-beta.1
     strategy:
       matrix:
         label:

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -28,7 +28,7 @@ jobs:
     name: ${{ matrix.label }}
     permissions:
       contents: read
-    uses: johnbillion/plugin-infrastructure/.github/workflows/reusable-static-analysis.yml@92a2affb0fe5c6f3c1a32eaefda057a326766196 # v2.1.0-beta.1
+    uses: johnbillion/plugin-infrastructure/.github/workflows/reusable-static-analysis.yml@5a327134e8fabebf5fbf0e8e31c46fa4d36b0d23 # v2.1.0-beta.2
     strategy:
       matrix:
         label:

--- a/.github/workflows/verify-distribution.yml
+++ b/.github/workflows/verify-distribution.yml
@@ -32,7 +32,7 @@ jobs:
   verify:
     name: Verify Plugin Distribution
     permissions: {}
-    uses: johnbillion/plugin-infrastructure/.github/workflows/reusable-verify-distribution.yml@1603731e84de084b9cc0a6d65b4dfb04ce3a96a1 # v2.0.0
+    uses: johnbillion/plugin-infrastructure/.github/workflows/reusable-verify-distribution.yml@92a2affb0fe5c6f3c1a32eaefda057a326766196 # v2.1.0-beta.1
     with:
       plugin: wp-crontrol
       owner: johnbillion

--- a/.github/workflows/verify-distribution.yml
+++ b/.github/workflows/verify-distribution.yml
@@ -32,7 +32,7 @@ jobs:
   verify:
     name: Verify Plugin Distribution
     permissions: {}
-    uses: johnbillion/plugin-infrastructure/.github/workflows/reusable-verify-distribution.yml@92a2affb0fe5c6f3c1a32eaefda057a326766196 # v2.1.0-beta.1
+    uses: johnbillion/plugin-infrastructure/.github/workflows/reusable-verify-distribution.yml@5a327134e8fabebf5fbf0e8e31c46fa4d36b0d23 # v2.1.0-beta.2
     with:
       plugin: wp-crontrol
       owner: johnbillion

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
 		}
 	},
 	"require-dev": {
-		"johnbillion/plugin-infrastructure": "2.0.0",
+		"johnbillion/plugin-infrastructure": "2.1.0-beta.2",
 		"johnbillion/wp-compat": "1.3.0",
 		"phpcompatibility/phpcompatibility-wp": "2.1.6",
 		"phpstan/phpstan": "2.1.12",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "1.19.2",
 			"license": "GPL-2.0-or-later",
 			"devDependencies": {
-				"@johnbillion/plugin-infrastructure": "2.0.0",
+				"@johnbillion/plugin-infrastructure": "2.1.0-beta.2",
 				"@jsdevtools/version-bump-prompt": "6.1.0",
 				"@playwright/test": "^1.55.0",
 				"@types/node": "^24.3.0",
@@ -21,9 +21,9 @@
 			}
 		},
 		"node_modules/@johnbillion/plugin-infrastructure": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@johnbillion/plugin-infrastructure/-/plugin-infrastructure-2.0.0.tgz",
-			"integrity": "sha512-LWazO4n52aC6HXOqssEekI7MMqkK9Qs997oP9tdF5hhwNTjImCquQnRcyQfBaCnfy5N1NonO64v35p6blgYdXg==",
+			"version": "2.1.0-beta.2",
+			"resolved": "https://registry.npmjs.org/@johnbillion/plugin-infrastructure/-/plugin-infrastructure-2.1.0-beta.2.tgz",
+			"integrity": "sha512-0MVb2mAAEhLwgSZmbkG+qHZcfWuw+13pGDWwAg7HrbmiUHzjJhQzJjswrmZrrCFZZ+oC9SE/bp+n549ZxT6SeQ==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
 		"node": ">=20"
 	},
 	"devDependencies": {
-		"@johnbillion/plugin-infrastructure": "2.0.0",
+		"@johnbillion/plugin-infrastructure": "2.1.0-beta.2",
 		"@jsdevtools/version-bump-prompt": "6.1.0",
 		"@playwright/test": "^1.55.0",
 		"@types/node": "^24.3.0",

--- a/tests/acceptance/playwright.config.ts
+++ b/tests/acceptance/playwright.config.ts
@@ -15,6 +15,7 @@ export default defineConfig({
 	use: {
 		baseURL,
 		...devices['Desktop Chrome'],
+		channel: 'chrome',
 		viewport: { width: 1440, height: 900 },
 		trace: 'on-first-retry',
 		screenshot: 'only-on-failure',

--- a/tests/acceptance/playwright.config.ts
+++ b/tests/acceptance/playwright.config.ts
@@ -19,7 +19,7 @@ export default defineConfig({
 		viewport: { width: 1440, height: 900 },
 		trace: 'on-first-retry',
 		screenshot: 'only-on-failure',
-		video: 'retain-on-failure',
+		video: process.env.CI ? 'off' : 'retain-on-failure',
 	},
 
 	webServer: undefined,

--- a/tests/acceptance/playwright.config.ts
+++ b/tests/acceptance/playwright.config.ts
@@ -15,7 +15,7 @@ export default defineConfig({
 	use: {
 		baseURL,
 		...devices['Desktop Chrome'],
-		channel: 'chrome',
+		channel: process.env.CI ? 'chrome' : undefined,
 		viewport: { width: 1440, height: 900 },
 		trace: 'on-first-retry',
 		screenshot: 'only-on-failure',


### PR DESCRIPTION
What this does:

* Removes `npx playwright install` from the setup steps
* Specifies `chrome` as the browser channel so the browser built in to [GitHub's Ubuntu 24.04 image](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md) is used
* Disables video recording on CI because ffmpeg isn't available in the image

See https://github.com/microsoft/playwright/issues/23388