### PR TITLE
Schedule tweaks

### DIFF
--- a/src/Event/Event.php
+++ b/src/Event/Event.php
@@ -245,7 +245,7 @@ abstract class Event {
 			return false;
 		}
 
-		return $schedules[ $this->schedule ]['is_too_frequent'];
+		return $schedules[ $this->schedule ]->is_too_frequent();
 	}
 
 	/**
@@ -289,7 +289,7 @@ abstract class Event {
 		$schedules = \Crontrol\Schedule\get();
 
 		if ( isset( $schedules[ $this->schedule ] ) ) {
-			return isset( $schedules[ $this->schedule ]['display'] ) ? $schedules[ $this->schedule ]['display'] : $schedules[ $this->schedule ]['name'];
+			return $schedules[ $this->schedule ]->display;
 		}
 
 		throw new UnknownScheduleException(

--- a/src/Exception/DuplicateScheduleException.php
+++ b/src/Exception/DuplicateScheduleException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Crontrol\Exception;
+
+/**
+ * Exception thrown when a schedule name already exists.
+ */
+class DuplicateScheduleException extends CrontrolRuntimeException {}

--- a/src/Schedule/CoreSchedule.php
+++ b/src/Schedule/CoreSchedule.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Represents a WordPress core cron schedule.
+ */
+
+namespace Crontrol\Schedule;
+
+/**
+ * Represents a WordPress core cron schedule.
+ */
+final class CoreSchedule extends Schedule {
+	/**
+	 * Check if this is a WordPress core schedule.
+	 *
+	 * @return bool True if this is a WordPress core schedule, false otherwise.
+	 */
+	#[\Override]
+	public function is_core_schedule(): bool {
+		return true;
+	}
+
+	/**
+	 * Check if this schedule is protected (cannot be deleted).
+	 *
+	 * Core schedules are always protected.
+	 *
+	 * @return bool True if the schedule is protected, false otherwise.
+	 */
+	#[\Override]
+	public function is_protected(): bool {
+		return true;
+	}
+}

--- a/src/Schedule/CustomSchedule.php
+++ b/src/Schedule/CustomSchedule.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Represents a custom cron schedule.
+ */
+
+namespace Crontrol\Schedule;
+
+/**
+ * Represents a custom cron schedule.
+ */
+final class CustomSchedule extends Schedule {
+	/**
+	 * Check if this schedule is custom (added by WP Crontrol).
+	 *
+	 * @return bool True if this is a custom schedule managed by WP Crontrol, false otherwise.
+	 */
+	#[\Override]
+	public function is_custom_schedule(): bool {
+		/** @var array<string,int|string> */
+		$custom_schedules = get_option( 'crontrol_schedules', array() );
+
+		return isset( $custom_schedules[ $this->name ] );
+	}
+
+	/**
+	 * Check if this schedule is protected (cannot be deleted).
+	 *
+	 * Custom schedules are protected if they're not managed by WP Crontrol
+	 * or if they're currently in use by events.
+	 *
+	 * @return bool True if the schedule is protected, false otherwise.
+	 */
+	#[\Override]
+	public function is_protected(): bool {
+		// If it's not a WP Crontrol custom schedule, it's protected
+		if ( ! $this->is_custom_schedule() ) {
+			return true;
+		}
+
+		// If it's in use, it's protected
+		return $this->is_in_use();
+	}
+}

--- a/src/Schedule/Schedule.php
+++ b/src/Schedule/Schedule.php
@@ -1,0 +1,117 @@
+<?php
+/**
+ * Base class for cron schedules.
+ */
+
+namespace Crontrol\Schedule;
+
+/**
+ * Base class for cron schedules.
+ */
+abstract class Schedule {
+	/**
+	 * The internal name of the schedule.
+	 *
+	 * @var string
+	 */
+	public string $name;
+
+	/**
+	 * The interval between executions in seconds.
+	 *
+	 * @var int
+	 */
+	public int $interval;
+
+	/**
+	 * The display name of the schedule.
+	 *
+	 * @var string
+	 */
+	public string $display;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param string $name     The internal name of the schedule.
+	 * @param int    $interval The interval between executions in seconds.
+	 * @param string $display  The display name of the schedule.
+	 */
+	protected function __construct( string $name, int $interval, string $display ) {
+		$this->name = $name;
+		$this->interval = $interval;
+		$this->display = $display;
+	}
+
+	/**
+	 * Factory method to create appropriate Schedule instance.
+	 *
+	 * @param string $name     The internal name of the schedule.
+	 * @param int    $interval The interval between executions in seconds.
+	 * @param string $display  The display name of the schedule.
+	 * @return self The appropriate Schedule instance.
+	 */
+	public static function create( string $name, int $interval, string $display ): self {
+		if ( in_array( $name, \Crontrol\get_core_schedules(), true ) ) {
+			return new CoreSchedule( $name, $interval, $display );
+		}
+
+		return new CustomSchedule( $name, $interval, $display );
+	}
+
+	/**
+	 * Check if this schedule's interval is too frequent (less than WP_CRON_LOCK_TIMEOUT).
+	 *
+	 * @return bool True if the schedule is too frequent, false otherwise.
+	 */
+	public function is_too_frequent(): bool {
+		return $this->interval < WP_CRON_LOCK_TIMEOUT;
+	}
+
+	/**
+	 * Check if this is a WordPress core schedule.
+	 *
+	 * @return bool True if this is a WordPress core schedule, false otherwise.
+	 */
+	public function is_core_schedule(): bool {
+		return false;
+	}
+
+	/**
+	 * Check if this schedule is custom (added by WP Crontrol).
+	 *
+	 * @return bool True if this is a custom schedule, false otherwise.
+	 */
+	public function is_custom_schedule(): bool {
+		return false;
+	}
+
+	/**
+	 * Check if this schedule is protected (cannot be deleted).
+	 *
+	 * A schedule is protected if it's a core schedule, added by another plugin,
+	 * or is currently in use by events.
+	 *
+	 * @return bool True if the schedule is protected, false otherwise.
+	 */
+	public function is_protected(): bool {
+		return false;
+	}
+
+	/**
+	 * Check if this schedule is currently in use by any events.
+	 *
+	 * @return bool True if the schedule is in use, false otherwise.
+	 */
+	public function is_in_use(): bool {
+		$events = \Crontrol\Event\get();
+
+		foreach ( $events as $event ) {
+			if ( $event->schedule === $this->name ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+}

--- a/src/bootstrap.php
+++ b/src/bootstrap.php
@@ -616,6 +616,12 @@ function action_handle_posts() {
 		$interval = absint( $_POST['crontrol_schedule_interval'] );
 		$display  = sanitize_text_field( wp_unslash( $_POST['crontrol_schedule_display_name'] ) );
 
+		// The internal name is used in array keys in WordPress, so it can't be purely numeric
+		// otherwise things go haywire when the schedule arrays pass through `array_merge()`.
+		if ( is_numeric( $name ) ) {
+			$name = 'schedule-' . $name;
+		}
+
 		Schedule\add( $name, $interval, $display );
 		$redirect = array(
 			'page'             => 'wp-crontrol-schedules',

--- a/src/bootstrap.php
+++ b/src/bootstrap.php
@@ -9,6 +9,7 @@ use Crontrol\Event\Table;
 use Crontrol\Event\PHPCronEvent;
 use Crontrol\Event\URLCronEvent;
 use Crontrol\Exception\CrontrolRuntimeException;
+use Crontrol\Exception\DuplicateScheduleException;
 use Crontrol\Exception\MissingURLException;
 use Crontrol\Exception\MissingHashException;
 use Crontrol\Exception\InvalidHashException;
@@ -44,6 +45,7 @@ const MESSAGE_UNKNOWN_ERROR = 'error';
 
 const MESSAGE_SCHEDULE_DELETED = 2;
 const MESSAGE_SCHEDULE_SAVED = 3;
+const MESSAGE_SCHEDULE_DUPLICATE = 4;
 
 /**
  * Hook onto all of the actions and filters needed by the plugin.
@@ -622,12 +624,20 @@ function action_handle_posts() {
 			$name = 'schedule-' . $name;
 		}
 
-		Schedule\add( $name, $interval, $display );
-		$redirect = array(
-			'page'             => 'wp-crontrol-schedules',
-			'crontrol_message' => MESSAGE_SCHEDULE_SAVED,
-			'crontrol_name'    => rawurlencode( $name ),
-		);
+		try {
+			Schedule\add( $name, $interval, $display );
+			$redirect = array(
+				'page'             => 'wp-crontrol-schedules',
+				'crontrol_message' => MESSAGE_SCHEDULE_SAVED,
+				'crontrol_name'    => rawurlencode( $name ),
+			);
+		} catch ( DuplicateScheduleException $e ) {
+			$redirect = array(
+				'page'             => 'wp-crontrol-schedules',
+				'crontrol_message' => MESSAGE_SCHEDULE_DUPLICATE,
+				'crontrol_name'    => rawurlencode( $name ),
+			);
+		}
 		wp_safe_redirect( add_query_arg( $redirect, admin_url( 'options-general.php' ) ) );
 		exit;
 
@@ -1189,6 +1199,11 @@ function admin_options_page() {
 			/* translators: %s: The name of the cron schedule. */
 			__( 'Added the cron schedule %s.', 'wp-crontrol' ),
 			'success',
+		),
+		MESSAGE_SCHEDULE_DUPLICATE => array(
+			/* translators: %s: The name of the cron schedule. */
+			__( 'A schedule with the name %s already exists.', 'wp-crontrol' ),
+			'error',
 		),
 	);
 	if ( isset( $_GET['crontrol_message'] ) && isset( $_GET['crontrol_name'] ) && isset( $messages[ $_GET['crontrol_message'] ] ) ) {

--- a/src/schedule-list-table.php
+++ b/src/schedule-list-table.php
@@ -5,6 +5,8 @@
 
 namespace Crontrol;
 
+use Crontrol\Schedule\Schedule;
+
 require_once ABSPATH . 'wp-admin/includes/class-wp-list-table.php';
 
 /**
@@ -12,18 +14,11 @@ require_once ABSPATH . 'wp-admin/includes/class-wp-list-table.php';
  */
 class Schedule_List_Table extends \WP_List_Table {
 	/**
-	 * Array of cron event schedules that are added by WordPress core.
+	 * Array of Schedule instances for the current page.
 	 *
-	 * @var array<int,string> Array of schedule names.
+	 * @var array<string,Schedule>
 	 */
-	protected static $core_schedules;
-
-	/**
-	 * Array of cron event schedule names that are in use by events.
-	 *
-	 * @var array<int,string> Array of schedule names.
-	 */
-	protected static $used_schedules;
+	public $items;
 
 	/**
 	 * Constructor.
@@ -52,11 +47,8 @@ class Schedule_List_Table extends \WP_List_Table {
 	 * @return void
 	 */
 	public function prepare_items() {
-		$schedules = Schedule\get();
+		$schedules = \Crontrol\Schedule\get();
 		$count     = count( $schedules );
-
-		self::$core_schedules = get_core_schedules();
-		self::$used_schedules = array_unique( wp_list_pluck( Event\get(), 'schedule' ) );
 
 		$this->items = $schedules;
 
@@ -93,15 +85,9 @@ class Schedule_List_Table extends \WP_List_Table {
 	/**
 	 * Generates and displays row action links for the table.
 	 *
-	 * @phpstan-param array{
-	 *   interval: int,
-	 *   display?: string,
-	 *   name: string,
-	 *   is_too_frequent: bool,
-	 * } $schedule
-	 * @param mixed[] $schedule    The schedule for the current row.
-	 * @param string  $column_name Current column name.
-	 * @param string  $primary     Primary column name.
+	 * @param Schedule $schedule    The schedule for the current row.
+	 * @param string   $column_name Current column name.
+	 * @param string   $primary     Primary column name.
 	 * @return string The row actions HTML.
 	 */
 	protected function handle_row_actions( $schedule, $column_name, $primary ) {
@@ -110,22 +96,20 @@ class Schedule_List_Table extends \WP_List_Table {
 		}
 
 		$links = array();
-		/** @var array<string,int|string> */
-		$new_scheds = get_option( 'crontrol_schedules', array() );
 
-		if ( in_array( $schedule['name'], self::$core_schedules, true ) ) {
+		if ( $schedule->is_core_schedule() ) {
 			$links[] = "<span class='crontrol-in-use'>" . esc_html__( 'This is a WordPress core schedule and cannot be deleted', 'wp-crontrol' ) . '</span>';
-		} elseif ( ! isset( $new_scheds[ $schedule['name'] ] ) ) {
+		} elseif ( ! $schedule->is_custom_schedule() ) {
 			$links[] = "<span class='crontrol-in-use'>" . esc_html__( 'This schedule is added by another plugin and cannot be deleted', 'wp-crontrol' ) . '</span>';
-		} elseif ( in_array( $schedule['name'], self::$used_schedules, true ) ) {
+		} elseif ( $schedule->is_in_use() ) {
 			$links[] = "<span class='crontrol-in-use'>" . esc_html__( 'This custom schedule is in use and cannot be deleted', 'wp-crontrol' ) . '</span>';
 		} else {
 			$link = add_query_arg( array(
 				'page'            => 'wp-crontrol-schedules',
 				'crontrol_action' => 'delete-schedule',
-				'crontrol_id'     => rawurlencode( $schedule['name'] ),
+				'crontrol_id'     => rawurlencode( $schedule->name ),
 			), admin_url( 'options-general.php' ) );
-			$link = wp_nonce_url( $link, 'crontrol-delete-schedule_' . $schedule['name'] );
+			$link = wp_nonce_url( $link, 'crontrol-delete-schedule_' . $schedule->name );
 
 			$links[] = "<span class='delete'><a href='" . esc_url( $link ) . "'>" . esc_html__( 'Delete', 'wp-crontrol' ) . '</a></span>';
 		}
@@ -136,17 +120,11 @@ class Schedule_List_Table extends \WP_List_Table {
 	/**
 	 * Returns the output for the icon cell of a table row.
 	 *
-	 * @phpstan-param array{
-	 *   interval: int,
-	 *   display?: string,
-	 *   name: string,
-	 *   is_too_frequent: bool,
-	 * } $schedule
-	 * @param mixed[] $schedule The schedule for the current row.
+	 * @param Schedule $schedule The schedule for the current row.
 	 * @return string The cell output.
 	 */
-	protected function column_crontrol_icon( array $schedule ) {
-		if ( in_array( $schedule['name'], self::$core_schedules, true ) ) {
+	protected function column_crontrol_icon( Schedule $schedule ) {
+		if ( $schedule->is_core_schedule() ) {
 			return sprintf(
 				'<span class="dashicons dashicons-wordpress" aria-hidden="true"></span>
 				<span class="screen-reader-text">%s</span>',
@@ -160,39 +138,27 @@ class Schedule_List_Table extends \WP_List_Table {
 	/**
 	 * Returns the output for the schedule name cell of a table row.
 	 *
-	 * @phpstan-param array{
-	 *   interval: int,
-	 *   display?: string,
-	 *   name: string,
-	 *   is_too_frequent: bool,
-	 * } $schedule
-	 * @param mixed[] $schedule The schedule for the current row.
+	 * @param Schedule $schedule The schedule for the current row.
 	 * @return string The cell output.
 	 */
-	protected function column_crontrol_name( array $schedule ) {
-		return esc_html( $schedule['name'] );
+	protected function column_crontrol_name( Schedule $schedule ) {
+		return esc_html( $schedule->name );
 	}
 
 	/**
 	 * Returns the output for the interval cell of a table row.
 	 *
-	 * @phpstan-param array{
-	 *   interval: int,
-	 *   display?: string,
-	 *   name: string,
-	 *   is_too_frequent: bool,
-	 * } $schedule
-	 * @param mixed[] $schedule The schedule for the current row.
+	 * @param Schedule $schedule The schedule for the current row.
 	 * @return string The cell output.
 	 */
-	protected function column_crontrol_interval( array $schedule ) {
+	protected function column_crontrol_interval( Schedule $schedule ) {
 		$interval = sprintf(
 			'%s (%s)',
-			esc_html( "{$schedule['interval']}" ),
-			esc_html( interval( $schedule['interval'], true ) )
+			esc_html( "{$schedule->interval}" ),
+			esc_html( interval( $schedule->interval, true ) )
 		);
 
-		if ( $schedule['is_too_frequent'] ) {
+		if ( $schedule->is_too_frequent() ) {
 			$interval .= sprintf(
 				'<span class="status-crontrol-warning"><br><span class="dashicons dashicons-warning" aria-hidden="true"></span> %s</span>',
 				sprintf(
@@ -210,18 +176,11 @@ class Schedule_List_Table extends \WP_List_Table {
 	/**
 	 * Returns the output for the display name cell of a table row.
 	 *
-	 * @param mixed[] $schedule The schedule for the current row.
-	 *
-	 * @phpstan-param array{
-	 *   interval: int,
-	 *   display?: string,
-	 *   name: string,
-	 *   is_too_frequent: bool,
-	 * } $schedule
+	 * @param Schedule $schedule The schedule for the current row.
 	 * @return string The cell output.
 	 */
-	protected function column_crontrol_display( array $schedule ) {
-		return esc_html( isset( $schedule['display'] ) ? $schedule['display'] : $schedule['name'] );
+	protected function column_crontrol_display( Schedule $schedule ) {
+		return esc_html( $schedule->display );
 	}
 
 	/**

--- a/src/schedule.php
+++ b/src/schedule.php
@@ -5,8 +5,12 @@
 
 namespace Crontrol\Schedule;
 
+use Crontrol\Exception\DuplicateScheduleException;
+
 /**
  * Adds a new custom cron schedule.
+ *
+ * @throws DuplicateScheduleException If the schedule name already exists.
  *
  * @param string $name     The internal name of the schedule.
  * @param int    $interval The interval between executions of the new schedule.
@@ -14,6 +18,18 @@ namespace Crontrol\Schedule;
  * @return void
  */
 function add( $name, $interval, $display ) {
+	$schedules = get();
+
+	if ( array_key_exists( $name, $schedules ) ) {
+		throw new DuplicateScheduleException(
+			sprintf(
+				/* translators: %s: The internal name of the schedule. */
+				__( 'A schedule with the name "%s" already exists.', 'wp-crontrol' ),
+				$name
+			)
+		);
+	}
+
 	/** @var array<string,int|string> */
 	$old_scheds = get_option( 'crontrol_schedules', array() );
 

--- a/src/schedule.php
+++ b/src/schedule.php
@@ -6,6 +6,7 @@
 namespace Crontrol\Schedule;
 
 use Crontrol\Exception\DuplicateScheduleException;
+use Crontrol\Schedule\Schedule;
 
 /**
  * Adds a new custom cron schedule.
@@ -72,13 +73,7 @@ function delete( $name ) {
 /**
  * Gets a sorted (according to interval) list of the cron schedules
  *
- * @return array<string,array<string,(int|string)>> Array of cron schedule arrays.
- * @phpstan-return array<string,array{
- *   interval: int,
- *   display?: string,
- *   name: string,
- *   is_too_frequent: bool,
- * }>
+ * @return array<string,Schedule> Array of Schedule objects keyed by schedule name.
  */
 function get() {
 	/**
@@ -95,23 +90,13 @@ function get() {
 		}
 	);
 
-	array_walk(
-		$schedules,
-		function ( array &$schedule, $name ) {
-			$schedule['name'] = $name;
-			$schedule['is_too_frequent'] = ( $schedule['interval'] < WP_CRON_LOCK_TIMEOUT );
-		}
-	);
+	$result = [];
+	foreach ( $schedules as $name => $schedule ) {
+		$display = $schedule['display'] ?? $name;
+		$result[ $name ] = Schedule::create( $name, $schedule['interval'], $display );
+	}
 
-	/**
-	 * @phpstan-var array<string,array{
-	 *   interval: int,
-	 *   display?: string,
-	 *   name: string,
-	 *   is_too_frequent: bool,
-	 * }> $schedules
-	 */
-	return $schedules;
+	return $result;
 }
 
 /**
@@ -125,13 +110,13 @@ function dropdown( ?string $current = null ) {
 	?>
 	<select class="postform" name="crontrol_schedule" id="crontrol_schedule" required>
 	<option <?php selected( $current, '_oneoff' ); ?> value="_oneoff"><?php esc_html_e( 'Non-repeating', 'wp-crontrol' ); ?></option>
-	<?php foreach ( $schedules as $sched_name => $sched_data ) { ?>
-		<option <?php selected( $current, $sched_name ); ?> value="<?php echo esc_attr( $sched_name ); ?>">
+	<?php foreach ( $schedules as $schedule ) { ?>
+		<option <?php selected( $current, $schedule->name ); ?> value="<?php echo esc_attr( $schedule->name ); ?>">
 			<?php
 			printf(
 				'%s (%s)',
-				esc_html( isset( $sched_data['display'] ) ? $sched_data['display'] : $sched_data['name'] ),
-				esc_html( $sched_name )
+				esc_html( $schedule->display ),
+				esc_html( $schedule->name )
 			);
 			?>
 		</option>

--- a/tests/acceptance/AddSchedule.spec.ts
+++ b/tests/acceptance/AddSchedule.spec.ts
@@ -89,4 +89,61 @@ test.describe( 'Adding Cron Schedules', () => {
 		await expect( scheduleRow.locator( '.column-crontrol_interval' ) ).toContainText( '456' );
 		await expect( scheduleRow.locator( '.column-crontrol_display' ) ).toContainText( 'Numeric Schedule' );
 	} );
+
+	test( 'Adding a schedule with a duplicate WordPress core schedule name', {
+		annotation: {
+			type: 'user-story',
+			description: 'As an administrator, I should see an error when trying to add a schedule with a name that already exists in WordPress core'
+		}
+	}, async ( {
+		page,
+		Crontrol,
+	} ) => {
+		await Crontrol.amOnCronScheduleListingPage();
+
+		// Try to add a schedule with the name 'hourly' which already exists
+		await page.getByLabel( 'Internal Name' ).fill( 'hourly' );
+		await page.getByLabel( 'Interval (seconds)' ).fill( '7200' );
+		await page.getByLabel( 'Display Name' ).fill( 'My Custom Hourly' );
+
+		// Submit the form
+		await page.getByRole( 'button', { name: 'Add Cron Schedule' } ).click();
+
+		// Verify error message
+		await expect( page.locator( '#crontrol-header' ) ).toContainText( 'Cron Schedules' );
+		await expect( page.locator( 'h1' ) ).toContainText( 'Cron Schedules' );
+		await Crontrol.seeAdminErrorNotice( 'A schedule with the name hourly already exists.' );
+	} );
+
+	test( 'Adding a schedule with a duplicate custom schedule name', {
+		annotation: {
+			type: 'user-story',
+			description: 'As an administrator, I should see an error when trying to add a schedule with a name that already exists as a custom schedule'
+		}
+	}, async ( {
+		page,
+		Crontrol,
+	} ) => {
+		await Crontrol.amOnCronScheduleListingPage();
+
+		// First, add a custom schedule
+		await page.getByLabel( 'Internal Name' ).fill( 'my_custom_schedule' );
+		await page.getByLabel( 'Interval (seconds)' ).fill( '1800' );
+		await page.getByLabel( 'Display Name' ).fill( 'My Custom Schedule' );
+		await page.getByRole( 'button', { name: 'Add Cron Schedule' } ).click();
+
+		// Verify it was added
+		await Crontrol.seeAdminSuccessNotice( 'Added the cron schedule my_custom_schedule.' );
+
+		// Now try to add another schedule with the same name
+		await page.getByLabel( 'Internal Name' ).fill( 'my_custom_schedule' );
+		await page.getByLabel( 'Interval (seconds)' ).fill( '3600' );
+		await page.getByLabel( 'Display Name' ).fill( 'Another Custom Schedule' );
+		await page.getByRole( 'button', { name: 'Add Cron Schedule' } ).click();
+
+		// Verify error message
+		await expect( page.locator( '#crontrol-header' ) ).toContainText( 'Cron Schedules' );
+		await expect( page.locator( 'h1' ) ).toContainText( 'Cron Schedules' );
+		await Crontrol.seeAdminErrorNotice( 'A schedule with the name my_custom_schedule already exists.' );
+	} );
 } );

--- a/tests/acceptance/AddSchedule.spec.ts
+++ b/tests/acceptance/AddSchedule.spec.ts
@@ -49,5 +49,44 @@ test.describe( 'Adding Cron Schedules', () => {
 		await expect( page.locator( '#crontrol-header' ) ).toContainText( 'Cron Schedules' );
 		await expect( page.locator( 'h1' ) ).toContainText( 'Cron Schedules' );
 		await Crontrol.seeAdminSuccessNotice( 'Added the cron schedule my_schedule_name.' );
+
+		// Verify the schedule appears in the table
+		const scheduleRow = page.locator( 'table tr' ).filter( { hasText: 'my_schedule_name' } );
+		await expect( scheduleRow ).toBeVisible();
+		await expect( scheduleRow.locator( '.column-crontrol_name' ) ).toContainText( 'my_schedule_name' );
+		await expect( scheduleRow.locator( '.column-crontrol_interval' ) ).toContainText( '123' );
+		await expect( scheduleRow.locator( '.column-crontrol_display' ) ).toContainText( 'My Schedule Name' );
+	} );
+
+	test( 'Adding a new schedule with a numeric internal name', {
+		annotation: {
+			type: 'user-story',
+			description: 'As an administrator, I need to be able to add a cron schedule with a numeric internal name'
+		}
+	}, async ( {
+		page,
+		Crontrol,
+	} ) => {
+		await Crontrol.amOnCronScheduleListingPage();
+
+		// Fill in the form fields with a numeric internal name
+		await page.getByLabel( 'Internal Name' ).fill( '123' );
+		await page.getByLabel( 'Interval (seconds)' ).fill( '456' );
+		await page.getByLabel( 'Display Name' ).fill( 'Numeric Schedule' );
+
+		// Submit the form
+		await page.getByRole( 'button', { name: 'Add Cron Schedule' } ).click();
+
+		// Verify success - the numeric name should be prefixed with 'schedule-'
+		await expect( page.locator( '#crontrol-header' ) ).toContainText( 'Cron Schedules' );
+		await expect( page.locator( 'h1' ) ).toContainText( 'Cron Schedules' );
+		await Crontrol.seeAdminSuccessNotice( 'Added the cron schedule schedule-123.' );
+
+		// Verify the schedule appears in the table with the prefixed name
+		const scheduleRow = page.locator( 'table tr' ).filter( { hasText: 'schedule-123' } );
+		await expect( scheduleRow ).toBeVisible();
+		await expect( scheduleRow.locator( '.column-crontrol_name' ) ).toContainText( 'schedule-123' );
+		await expect( scheduleRow.locator( '.column-crontrol_interval' ) ).toContainText( '456' );
+		await expect( scheduleRow.locator( '.column-crontrol_display' ) ).toContainText( 'Numeric Schedule' );
 	} );
 } );

--- a/tests/integration/ScheduleTest.php
+++ b/tests/integration/ScheduleTest.php
@@ -1,0 +1,55 @@
+<?php declare(strict_types = 1);
+
+namespace Crontrol\Tests;
+
+use Crontrol\Exception\DuplicateScheduleException;
+use Crontrol\Schedule;
+
+class ScheduleTest extends Test {
+	/**
+	 * @covers \Crontrol\Schedule\add
+	 */
+	public function testAddScheduleThrowsExceptionForDuplicateCoreSchedule(): void {
+		self::expectException( DuplicateScheduleException::class );
+
+		// Attempt to add a schedule with a name that already exists (hourly is a core schedule)
+		Schedule\add( 'hourly', 3600, 'Test Hourly' );
+	}
+
+	/**
+	 * @covers \Crontrol\Schedule\add
+	 */
+	public function testAddScheduleThrowsExceptionForDuplicateCustomSchedule(): void {
+		$schedule_name = 'test_duplicate_schedule_' . time();
+
+		// First, add a custom schedule
+		Schedule\add( $schedule_name, 1800, 'Test Schedule' );
+
+		// Verify it was added
+		$schedules = Schedule\get();
+		self::assertArrayHasKey( $schedule_name, $schedules );
+
+		// Now attempt to add a schedule with the same name
+		self::expectException( DuplicateScheduleException::class );
+
+		Schedule\add( $schedule_name, 3600, 'Another Test Schedule' );
+	}
+
+	/**
+	 * @covers \Crontrol\Schedule\add
+	 */
+	public function testAddScheduleSucceedsForNewSchedule(): void {
+		$schedule_name = 'test_schedule_' . time();
+
+		// This should not throw an exception
+		Schedule\add( $schedule_name, 7200, 'Test Schedule' );
+
+		// Verify the schedule was added
+		$schedules = Schedule\get();
+		self::assertArrayHasKey( $schedule_name, $schedules );
+		$schedule = $schedules[ $schedule_name ];
+		self::assertEquals( 7200, $schedule['interval'] );
+		self::assertArrayHasKey( 'display', $schedule );
+		self::assertEquals( 'Test Schedule', $schedule['display'] );
+	}
+}

--- a/tests/integration/ScheduleTest.php
+++ b/tests/integration/ScheduleTest.php
@@ -4,6 +4,9 @@ namespace Crontrol\Tests;
 
 use Crontrol\Exception\DuplicateScheduleException;
 use Crontrol\Schedule;
+use Crontrol\Schedule\Schedule as ScheduleClass;
+use Crontrol\Schedule\CoreSchedule;
+use Crontrol\Schedule\CustomSchedule;
 
 class ScheduleTest extends Test {
 	/**
@@ -48,8 +51,146 @@ class ScheduleTest extends Test {
 		$schedules = Schedule\get();
 		self::assertArrayHasKey( $schedule_name, $schedules );
 		$schedule = $schedules[ $schedule_name ];
-		self::assertEquals( 7200, $schedule['interval'] );
-		self::assertArrayHasKey( 'display', $schedule );
-		self::assertEquals( 'Test Schedule', $schedule['display'] );
+		self::assertInstanceOf( CustomSchedule::class, $schedule );
+		self::assertEquals( 7200, $schedule->interval );
+		self::assertEquals( 'Test Schedule', $schedule->display );
+	}
+
+	/**
+	 * @covers \Crontrol\Schedule\Schedule::create
+	 */
+	public function testCreatesCoreScheduleForCoreSchedules(): void {
+		$schedule = ScheduleClass::create( 'hourly', 3600, 'Once Hourly' );
+
+		self::assertInstanceOf( CoreSchedule::class, $schedule );
+		self::assertSame( 'hourly', $schedule->name );
+		self::assertSame( 3600, $schedule->interval );
+		self::assertSame( 'Once Hourly', $schedule->display );
+		self::assertTrue( $schedule->is_core_schedule() );
+		self::assertTrue( $schedule->is_protected() );
+		self::assertFalse( $schedule->is_custom_schedule() );
+	}
+
+	/**
+	 * @covers \Crontrol\Schedule\Schedule::create
+	 */
+	public function testCreatesCustomScheduleForNonCoreSchedules(): void {
+		$schedule = ScheduleClass::create( 'custom_schedule', 7200, 'Every Two Hours' );
+
+		self::assertInstanceOf( CustomSchedule::class, $schedule );
+		self::assertSame( 'custom_schedule', $schedule->name );
+		self::assertSame( 7200, $schedule->interval );
+		self::assertSame( 'Every Two Hours', $schedule->display );
+		self::assertFalse( $schedule->is_core_schedule() );
+		self::assertFalse( $schedule->is_custom_schedule() ); // Not a WP Crontrol custom schedule
+	}
+
+	/**
+	 * @covers \Crontrol\Schedule\Schedule::is_too_frequent
+	 */
+	public function testDetectsTooFrequentSchedules(): void {
+		// Create a schedule with interval less than WP_CRON_LOCK_TIMEOUT
+		$fast_schedule = ScheduleClass::create( 'very_fast', 30, 'Every 30 Seconds' );
+
+		self::assertTrue( $fast_schedule->is_too_frequent() );
+
+		// Create a schedule with interval greater than WP_CRON_LOCK_TIMEOUT
+		$slow_schedule = ScheduleClass::create( 'slow', 3600, 'Every Hour' );
+
+		self::assertFalse( $slow_schedule->is_too_frequent() );
+	}
+
+	/**
+	 * @covers \Crontrol\Schedule\Schedule::is_custom_schedule
+	 */
+	public function testDetectsCustomSchedulesManagedByWPCrontrol(): void {
+		// Add a custom schedule via WP Crontrol
+		Schedule\add( 'wp_crontrol_custom', 1800, 'Custom Schedule' );
+
+		$schedules = Schedule\get();
+		$schedule = $schedules['wp_crontrol_custom'];
+
+		self::assertTrue( $schedule->is_custom_schedule() );
+		self::assertInstanceOf( CustomSchedule::class, $schedule );
+	}
+
+	/**
+	 * @covers \Crontrol\Schedule\Schedule::is_in_use
+	 * @covers \Crontrol\Schedule\Schedule::is_protected
+	 */
+	public function testDetectsSchedulesInUse(): void {
+		// Add a custom schedule
+		Schedule\add( 'test_schedule_in_use', 3600, 'Test Schedule' );
+
+		// Add an event that uses this schedule
+		$timestamp = time() + 3600;
+		wp_schedule_event( $timestamp, 'test_schedule_in_use', 'test_hook_for_schedule' );
+
+		$schedules = Schedule\get();
+		$schedule = $schedules['test_schedule_in_use'];
+
+		self::assertTrue( $schedule->is_in_use() );
+		self::assertTrue( $schedule->is_protected() ); // Protected because it's in use
+	}
+
+	/**
+	 * @covers \Crontrol\Schedule\Schedule::is_in_use
+	 * @covers \Crontrol\Schedule\Schedule::is_protected
+	 */
+	public function testDetectsSchedulesNotInUse(): void {
+		// Add a custom schedule but don't use it
+		Schedule\add( 'test_schedule_not_in_use', 3600, 'Unused Schedule' );
+
+		$schedules = Schedule\get();
+		$schedule = $schedules['test_schedule_not_in_use'];
+
+		self::assertFalse( $schedule->is_in_use() );
+		self::assertFalse( $schedule->is_protected() ); // Not protected since it's not in use
+	}
+
+	/**
+	 * @covers \Crontrol\Schedule\Schedule::is_protected
+	 */
+	public function testCustomScheduleIsProtectedWhenNotManagedByWPCrontrol(): void {
+		// Simulate a schedule added by another plugin
+		add_filter( 'cron_schedules', function ( $schedules ) {
+			$schedules['external_plugin_schedule'] = array(
+				'interval' => 7200,
+				'display'  => 'External Plugin Schedule',
+			);
+			return $schedules;
+		} );
+
+		$schedules = Schedule\get();
+		$schedule = $schedules['external_plugin_schedule'];
+
+		self::assertInstanceOf( CustomSchedule::class, $schedule );
+		self::assertFalse( $schedule->is_custom_schedule() ); // Not a WP Crontrol schedule
+		self::assertTrue( $schedule->is_protected() ); // Protected because it's from another plugin
+	}
+
+	/**
+	 * @return array<string, array{string}>
+	 */
+	public static function dataCoreScheduleNames(): array {
+		return array(
+			'hourly' => array( 'hourly' ),
+			'twicedaily' => array( 'twicedaily' ),
+			'daily' => array( 'daily' ),
+			'weekly' => array( 'weekly' ),
+		);
+	}
+
+	/**
+	 * @dataProvider dataCoreScheduleNames
+	 * @covers \Crontrol\Schedule\CoreSchedule::is_protected
+	 */
+	public function testCoreScheduleIsAlwaysProtected( string $name ): void {
+		$schedules = Schedule\get();
+		$schedule = $schedules[ $name ];
+
+		self::assertTrue( $schedule->is_core_schedule(), "Schedule '{$name}' should be a core schedule" );
+		self::assertTrue( $schedule->is_protected(), "Schedule '{$name}' should be protected" );
+		self::assertInstanceOf( CoreSchedule::class, $schedule );
 	}
 }


### PR DESCRIPTION
* Adds a prefix to numeric schedule names, which are otherwise broken due to them being used as array keys and passing through `array_merge()` in WordPress core.
* Prevents attempts to add duplicate schedules.