### PR TITLE
Correctly handle closures as cron event actions

### DIFF
--- a/src/bootstrap.php
+++ b/src/bootstrap.php
@@ -2291,7 +2291,13 @@ function get_hook_callbacks( $name ) {
 function populate_callback( array $callback ) {
 	// If Query Monitor is installed, use its rich callback analysis.
 	if ( method_exists( '\QM_Util', 'populate_callback' ) ) {
-		return \QM_Util::populate_callback( $callback );
+		$qm_callback = \QM_Util::populate_callback( $callback );
+
+		if ( ( ! isset( $qm_callback['name'] ) ) && is_object( $callback['function'] ) && is_a( $callback['function'], 'Closure' ) ) {
+			$qm_callback['name'] = '{closure:/}';
+		}
+
+		return $qm_callback;
 	}
 
 	if ( is_string( $callback['function'] ) && ( false !== strpos( $callback['function'], '::' ) ) ) {


### PR DESCRIPTION
Fixes #227.

The underlying problem is actually in Query Monitor. It handles several "callback" structures from `WP_Hook`, PHP error stack traces, and function call stack traces, but they all have a different structure. Internally, QM correctly handles closures for hook callbacks, but not one passed directly to `QM_Util::populate_callback()`.

For now I'm fixing this in WP Crontrol. QM needs some reworking so it handles different "callback" types rather than trying to unify them.