### PR TITLE
Add testing on WP 6.9-RC1

### DIFF
--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -58,7 +58,7 @@ jobs:
           - wp: '6.3'
             php: '7.4'
       fail-fast: false
-    uses: johnbillion/plugin-infrastructure/.github/workflows/reusable-acceptance-tests.yml@9a6405c89f3357947cd8f608bdc72d68fe17f4ae # 2.1.2
+    uses: johnbillion/plugin-infrastructure/.github/workflows/reusable-acceptance-tests.yml@a37eeb04e7bfc8d6b6459e05e0392b265c03da50 # 2.1.3
     with:
       node: false
       php: ${{ matrix.php }}

--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -44,15 +44,15 @@ jobs:
       matrix:
         wp:
           # Latest three stable:
+          - '6.9-RC1'
           - '6.8'
           - '6.7'
-          - '6.6'
         php:
           - '8.3'
           - '7.4'
         include:
           # Latest stable on PHP 8.4:
-          - wp: '6.8'
+          - wp: '6.9-RC1'
             php: '8.4'
           # Oldest supported on PHP 7.4:
           - wp: '6.3'

--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -54,8 +54,10 @@ jobs:
           # Latest stable on PHP 8.4:
           - wp: '6.9-RC1'
             php: '8.4'
-          # Oldest supported on PHP 7.4:
-          - wp: '6.3'
+          # Oldest supported WordPress on its newest and oldest supported PHP:
+          - wp: '6.4'
+            php: '8.3'
+          - wp: '6.4'
             php: '7.4'
       fail-fast: false
     uses: johnbillion/plugin-infrastructure/.github/workflows/reusable-acceptance-tests.yml@9a6405c89f3357947cd8f608bdc72d68fe17f4ae # 2.1.2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
     name: Build
     permissions:
       contents: write
-    uses: johnbillion/plugin-infrastructure/.github/workflows/reusable-build.yml@9a6405c89f3357947cd8f608bdc72d68fe17f4ae # 2.1.2
+    uses: johnbillion/plugin-infrastructure/.github/workflows/reusable-build.yml@a37eeb04e7bfc8d6b6459e05e0392b265c03da50 # 2.1.3
     with:
       node: false
       tag: ${{ github.event_name != 'workflow_dispatch' }}

--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -32,7 +32,7 @@ jobs:
     name: ${{ matrix.label }}
     permissions:
       contents: read
-    uses: johnbillion/plugin-infrastructure/.github/workflows/reusable-coding-standards.yml@9a6405c89f3357947cd8f608bdc72d68fe17f4ae # 2.1.2
+    uses: johnbillion/plugin-infrastructure/.github/workflows/reusable-coding-standards.yml@a37eeb04e7bfc8d6b6459e05e0392b265c03da50 # 2.1.3
     strategy:
       matrix:
         label:

--- a/.github/workflows/deploy-assets.yml
+++ b/.github/workflows/deploy-assets.yml
@@ -13,7 +13,7 @@ jobs:
     name: WordPress.org
     permissions:
       contents: read
-    uses: johnbillion/plugin-infrastructure/.github/workflows/reusable-deploy-assets.yml@9a6405c89f3357947cd8f608bdc72d68fe17f4ae # 2.1.2
+    uses: johnbillion/plugin-infrastructure/.github/workflows/reusable-deploy-assets.yml@a37eeb04e7bfc8d6b6459e05e0392b265c03da50 # 2.1.3
     with:
       plugin: wp-crontrol
       readme: readme.txt

--- a/.github/workflows/deploy-tag.yml
+++ b/.github/workflows/deploy-tag.yml
@@ -18,7 +18,7 @@ permissions: {}
 jobs:
   deploy:
     name: Deploy Tag
-    uses: johnbillion/plugin-infrastructure/.github/workflows/reusable-deploy-tag.yml@9a6405c89f3357947cd8f608bdc72d68fe17f4ae # 2.1.2
+    uses: johnbillion/plugin-infrastructure/.github/workflows/reusable-deploy-tag.yml@a37eeb04e7bfc8d6b6459e05e0392b265c03da50 # 2.1.3
     permissions:
       contents: read
       issues: write

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -40,7 +40,7 @@ jobs:
     name: WP ${{ matrix.wp }}
     permissions:
       contents: read
-    uses: johnbillion/plugin-infrastructure/.github/workflows/reusable-integration-tests.yml@9a6405c89f3357947cd8f608bdc72d68fe17f4ae # 2.1.2
+    uses: johnbillion/plugin-infrastructure/.github/workflows/reusable-integration-tests.yml@a37eeb04e7bfc8d6b6459e05e0392b265c03da50 # 2.1.3
     strategy:
       # See the following for PHP compatibility of WordPress versions:
       # https://make.wordpress.org/core/handbook/references/php-compatibility-and-wordpress-versions/

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -58,8 +58,10 @@ jobs:
           # Latest WordPress on PHP 8.4
           - wp: '6.9-RC1'
             php: '8.4'
-          # Oldest supported WordPress
-          - wp: '6.3'
+          # Oldest supported WordPress on its newest and oldest supported PHP:
+          - wp: '6.4'
+            php: '8.3'
+          - wp: '6.4'
             php: '7.4'
       fail-fast: false
     with:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -47,16 +47,16 @@ jobs:
       matrix:
         wp:
           # Three most recent versions of WordPress
+          - '6.9-RC1'
           - '6.8'
           - '6.7'
-          - '6.6'
         php:
           # Most recent version of PHP supported by all of the above, plus 7.4
           - '8.3'
           - '7.4'
         include:
           # Latest WordPress on PHP 8.4
-          - wp: '6.8'
+          - wp: '6.9-RC1'
             php: '8.4'
           # Oldest supported WordPress
           - wp: '6.3'

--- a/.github/workflows/lint-workflows.yml
+++ b/.github/workflows/lint-workflows.yml
@@ -27,4 +27,4 @@ jobs:
       security-events: write
       actions: read
       contents: read
-    uses: johnbillion/plugin-infrastructure/.github/workflows/reusable-workflow-lint.yml@9a6405c89f3357947cd8f608bdc72d68fe17f4ae # 2.1.2
+    uses: johnbillion/plugin-infrastructure/.github/workflows/reusable-workflow-lint.yml@a37eeb04e7bfc8d6b6459e05e0392b265c03da50 # 2.1.3

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -37,7 +37,7 @@ jobs:
           - '8.3'
           - '7.4'
       fail-fast: false
-    uses: johnbillion/plugin-infrastructure/.github/workflows/reusable-acceptance-tests.yml@9a6405c89f3357947cd8f608bdc72d68fe17f4ae # 2.1.2
+    uses: johnbillion/plugin-infrastructure/.github/workflows/reusable-acceptance-tests.yml@a37eeb04e7bfc8d6b6459e05e0392b265c03da50 # 2.1.3
     with:
       node: false
       php: ${{ matrix.php }}
@@ -48,7 +48,7 @@ jobs:
     name: Nightly ${{ matrix.label }}
     permissions:
       contents: read
-    uses: johnbillion/plugin-infrastructure/.github/workflows/reusable-integration-tests.yml@9a6405c89f3357947cd8f608bdc72d68fe17f4ae # 2.1.2
+    uses: johnbillion/plugin-infrastructure/.github/workflows/reusable-integration-tests.yml@a37eeb04e7bfc8d6b6459e05e0392b265c03da50 # 2.1.3
     strategy:
       matrix:
         label:

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -28,7 +28,7 @@ jobs:
     name: ${{ matrix.label }}
     permissions:
       contents: read
-    uses: johnbillion/plugin-infrastructure/.github/workflows/reusable-static-analysis.yml@9a6405c89f3357947cd8f608bdc72d68fe17f4ae # 2.1.2
+    uses: johnbillion/plugin-infrastructure/.github/workflows/reusable-static-analysis.yml@a37eeb04e7bfc8d6b6459e05e0392b265c03da50 # 2.1.3
     strategy:
       matrix:
         label:

--- a/.github/workflows/verify-distribution.yml
+++ b/.github/workflows/verify-distribution.yml
@@ -33,7 +33,7 @@ jobs:
     name: Verify Plugin Distribution
     permissions:
       contents: read
-    uses: johnbillion/plugin-infrastructure/.github/workflows/reusable-verify-distribution.yml@9a6405c89f3357947cd8f608bdc72d68fe17f4ae # 2.1.2
+    uses: johnbillion/plugin-infrastructure/.github/workflows/reusable-verify-distribution.yml@a37eeb04e7bfc8d6b6459e05e0392b265c03da50 # 2.1.3
     with:
       plugin: wp-crontrol
       owner: johnbillion

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
 		}
 	},
 	"require-dev": {
-		"johnbillion/plugin-infrastructure": "2.1.2",
+		"johnbillion/plugin-infrastructure": "2.1.3",
 		"johnbillion/wp-compat": "1.3.0",
 		"phpcompatibility/phpcompatibility-wp": "2.1.6",
 		"phpstan/phpstan": "2.1.12",

--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,7 @@
 	"require-dev": {
 		"johnbillion/plugin-infrastructure": "2.1.3",
 		"johnbillion/wp-compat": "1.3.0",
+		"php-stubs/wordpress-stubs": "6.8.2",
 		"phpcompatibility/phpcompatibility-wp": "2.1.6",
 		"phpstan/phpstan": "2.1.12",
 		"szepeviktor/phpstan-wordpress": "2.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
 	"name": "wp-crontrol",
-	"version": "1.19.2",
+	"version": "1.19.3",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "wp-crontrol",
-			"version": "1.19.2",
+			"version": "1.19.3",
 			"license": "GPL-2.0-or-later",
 			"devDependencies": {
-				"@johnbillion/plugin-infrastructure": "2.1.2",
+				"@johnbillion/plugin-infrastructure": "2.1.3",
 				"@jsdevtools/version-bump-prompt": "6.1.0",
 				"@playwright/test": "^1.55.0",
 				"@types/node": "^24.3.0",
@@ -21,9 +21,9 @@
 			}
 		},
 		"node_modules/@johnbillion/plugin-infrastructure": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/@johnbillion/plugin-infrastructure/-/plugin-infrastructure-2.1.2.tgz",
-			"integrity": "sha512-9G7vGOBv1J4a5V312GzcUFmJVJDEGxgf7Dcru+gGGeLYZ5VnSOcQOwtVj1VOw+CKGmr068VtQCHBB1aKZ5qQCw==",
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/@johnbillion/plugin-infrastructure/-/plugin-infrastructure-2.1.3.tgz",
+			"integrity": "sha512-9VOaVidt5lVc4hW3QfMTV5XM0cJ19s4BHQaaZ+LjmNoTdJrxxsClPYmDzZocxTI9jUYglVvJ8/y89HLks+mfYA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
 		"node": ">=20"
 	},
 	"devDependencies": {
-		"@johnbillion/plugin-infrastructure": "2.1.2",
+		"@johnbillion/plugin-infrastructure": "2.1.3",
 		"@jsdevtools/version-bump-prompt": "6.1.0",
 		"@playwright/test": "^1.55.0",
 		"@types/node": "^24.3.0",

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -2,7 +2,7 @@
 <ruleset name="WP Crontrol">
 
 	<config name="testVersion" value="7.4-"/>
-	<config name="minimum_wp_version" value="6.3"/>
+	<config name="minimum_wp_version" value="6.4"/>
 	<arg name="extensions" value="php"/>
 	<arg name="cache" value="tests/cache/phpcs.json"/>
 

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 
 Contributors: johnbillion, scompt
 Tags: cron, wp-cron, crontrol, debug, woocommerce
-Tested up to: 6.8
+Tested up to: 6.9
 Stable tag: 1.19.3
 License: GPL v2 or later
 Donate link: https://github.com/sponsors/johnbillion

--- a/wp-crontrol.php
+++ b/wp-crontrol.php
@@ -8,7 +8,7 @@
  * Version:      1.19.3
  * Text Domain:  wp-crontrol
  * Domain Path:  /languages/
- * Requires at least: 6.3
+ * Requires at least: 6.4
  * Requires PHP: 7.4
  * License URI:  https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
  * License:      GPL v2 or later


### PR DESCRIPTION
* Bumps testing to 6.9-RC1
* Bumps minimum supported WordPress version from 6.3 to 6.4
* Pins `php-stubs/wordpress-stubs` to 6.8.2 due to https://github.com/php-stubs/wordpress-stubs/issues/405