### PR TITLE
Add support for handling invalid args

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -26,7 +26,3 @@ parameters:
 	ignoreErrors:
 		-
 			message: '#^Call to function method_exists\(\) with ''\\\\QM_Util'' and ''populate_callback'' will always evaluate to true\.$#'
-		-
-			# We can't guarantee that args from custom events are a list
-			message: '#^Parameter \#3 \$args of function wp_unschedule_event expects list<mixed>, array<mixed> given\.$#'
-			path: src/event.php

--- a/src/Event/Event.php
+++ b/src/Event/Event.php
@@ -42,9 +42,12 @@ abstract class Event {
 	/**
 	 * The arguments to pass to the hook's callback function.
 	 *
-	 * @var mixed[]
+	 * Note: This should normally be an array, but may contain other types if
+	 * the cron data is corrupted or invalid. Check has_invalid_args property.
+	 *
+	 * @var mixed[]|mixed
 	 */
-	public array $args;
+	public $args;
 
 	/**
 	 * The schedule name or null for one-time events.
@@ -61,6 +64,11 @@ abstract class Event {
 	public $interval;
 
 	/**
+	 * Whether this event has invalid (non-array) args.
+	 */
+	public bool $has_invalid_args = false;
+
+	/**
 	 * Constructor.
 	 *
 	 * @param string      $hook The hook name of the cron event.
@@ -70,13 +78,16 @@ abstract class Event {
 	 * @param string|null $schedule The schedule name or null for one-time events.
 	 * @param int|null    $interval The interval time in seconds for the schedule. Only present for recurring events.
 	 */
-	protected function __construct( string $hook, int $timestamp, string $sig, array $args, ?string $schedule, ?int $interval ) {
+	protected function __construct( string $hook, int $timestamp, string $sig, $args, ?string $schedule, ?int $interval ) {
 		$this->hook = $hook;
 		$this->timestamp = $timestamp;
 		$this->sig = $sig;
 		$this->args = $args;
 		$this->schedule = $schedule;
 		$this->interval = $interval;
+		// Args should be an array but corrupted or invalid cron data may contain other types.
+		// @phpstan-ignore function.alreadyNarrowedType
+		$this->has_invalid_args = ! is_array( $args );
 	}
 
 	/**
@@ -96,7 +107,7 @@ abstract class Event {
 	 *   (CoreCronEvent|StandardEvent)
 	 * )
 	 */
-	public static function create( string $hook, int $timestamp, string $sig, array $args, ?string $schedule, ?int $interval ): self {
+	public static function create( string $hook, int $timestamp, string $sig, $args, ?string $schedule, ?int $interval ): self {
 		if ( PHPCronEvent::HOOK_NAME === $hook ) {
 			return new PHPCronEvent( $hook, $timestamp, $sig, $args, $schedule, $interval );
 		}
@@ -132,7 +143,7 @@ abstract class Event {
 	 * @param mixed[] $args The arguments to pass to the hook's callback function.
 	 * @return self The appropriate Event instance set to run immediately.
 	 */
-	public static function create_immediate( string $hook, array $args = array() ): self {
+	public static function create_immediate( string $hook, $args = array() ): self {
 		return self::create( $hook, 1, '', $args, null, null );
 	}
 
@@ -226,7 +237,14 @@ abstract class Event {
 	 * Check if this event has any errors (syntax errors, URL errors, or integrity failures).
 	 */
 	public function has_error(): bool {
-		return false;
+		return $this->has_invalid_args;
+	}
+
+	/**
+	 * Check if this event has invalid (non-array) args.
+	 */
+	public function has_invalid_args(): bool {
+		return $this->has_invalid_args;
 	}
 
 	/**

--- a/src/Event/Event.php
+++ b/src/Event/Event.php
@@ -43,7 +43,7 @@ abstract class Event {
 	 * The arguments to pass to the hook's callback function.
 	 *
 	 * Note: This should normally be an array, but may contain other types if
-	 * the cron data is corrupted or invalid. Check has_invalid_args property.
+	 * the cron data is corrupted or invalid. Check the has_invalid_args() method.
 	 *
 	 * @var mixed[]|mixed
 	 */

--- a/src/bootstrap.php
+++ b/src/bootstrap.php
@@ -1638,7 +1638,13 @@ function show_cron_form( $editing ) {
 		$other_fields .= sprintf( '<input name="crontrol_original_next_run_utc" type="hidden" value="%s" />',
 			esc_attr( (string) $existing->timestamp )
 		);
-		if ( ! empty( $existing->args ) ) {
+		if ( $existing->has_invalid_args() ) {
+			$display_args = wp_json_encode( $existing->args );
+
+			if ( false === $display_args ) {
+				$display_args = var_export( $existing->args, true );
+			}
+		} elseif ( $existing->args !== [] ) {
 			$display_args = wp_json_encode( $existing->args );
 
 			if ( false === $display_args ) {
@@ -1892,6 +1898,20 @@ function show_cron_form( $editing ) {
 							</label>
 						</th>
 						<td>
+							<?php
+							// @phpstan-ignore booleanAnd.rightAlwaysTrue
+							if ( $editing && $existing && $existing->has_invalid_args() ) {
+								printf(
+									'<div class="notice notice-error inline"><p>%1$s</p><p>%2$s</p></div>',
+									esc_html__( 'This event has invalid arguments and will not run correctly.', 'wp-crontrol' ),
+									sprintf(
+										/* translators: %s: The PHP type of the invalid value */
+										esc_html__( 'Arguments should be an array but %s was provided. The event will likely fail with a PHP error when it attempts to run.', 'wp-crontrol' ),
+										esc_html( gettype( $existing->args ) )
+									)
+								);
+							}
+							?>
 							<input type="text" autocorrect="off" autocapitalize="off" spellcheck="false" class="regular-text code" id="crontrol_args" name="crontrol_args" value="<?php echo esc_attr( $display_args ); ?>" aria-describedby="crontrol_args_description"/>
 							<?php do_action( 'crontrol/manage/args', $existing ); ?>
 							<p class="description" id="crontrol_args_description">

--- a/src/bootstrap.php
+++ b/src/bootstrap.php
@@ -1899,8 +1899,7 @@ function show_cron_form( $editing ) {
 						</th>
 						<td>
 							<?php
-							// @phpstan-ignore booleanAnd.rightAlwaysTrue
-							if ( $editing && $existing && $existing->has_invalid_args() ) {
+							if ( $editing && $existing->has_invalid_args() ) {
 								printf(
 									'<div class="notice notice-error inline"><p>%1$s</p><p>%2$s</p></div>',
 									esc_html__( 'This event has invalid arguments and will not run correctly.', 'wp-crontrol' ),

--- a/src/event-list-table.php
+++ b/src/event-list-table.php
@@ -727,7 +727,14 @@ class Table extends \WP_List_Table {
 			);
 		}
 
-		if ( ! empty( $event->args ) ) {
+		if ( $event->has_invalid_args() ) {
+			$output .= sprintf(
+				'<br><span class="status-crontrol-error"><span class="dashicons dashicons-warning" aria-hidden="true"></span> %s</span>',
+				esc_html__( 'This event has invalid arguments and will not run correctly.', 'wp-crontrol' )
+			);
+		}
+
+		if ( $event->args !== [] ) {
 			$output .= sprintf(
 				'<br><details><summary>%s</summary><pre>%s</pre></details>',
 				esc_html__( 'View arguments', 'wp-crontrol' ),

--- a/tests/integration/EventTest.php
+++ b/tests/integration/EventTest.php
@@ -396,4 +396,33 @@ class EventTest extends Test {
 		self::assertInstanceOf( StandardEvent::class, $found_event );
 		self::assertSame( array(), $found_event->args );
 	}
+
+	/**
+	 * @dataProvider dataInvalidArgs
+	 * @param mixed $args The args value to test.
+	 * @param bool $is_invalid Whether the args should be marked as invalid.
+	 */
+	public function testArgsValidity( $args, bool $is_invalid ): void {
+		$event = Event::create( 'test_args_validity', time() + 3600, 'test_sig', $args, null, null );
+
+		self::assertInstanceOf( StandardEvent::class, $event );
+		self::assertSame( $args, $event->args );
+		self::assertSame( $is_invalid, $event->has_invalid_args() );
+		self::assertSame( $is_invalid, $event->has_error() );
+	}
+
+	/**
+	 * @return array<string, array{mixed, bool}>
+	 */
+	public static function dataInvalidArgs(): array {
+		return array(
+			'string' => array( 'this is a string', true ),
+			'null' => array( null, true ),
+			'integer' => array( 42, true ),
+			'bool false' => array( false, true ),
+			'bool true' => array( true, true ),
+			'empty array' => array( array(), false ),
+			'array with values' => array( array( 'key' => 'value' ), false ),
+		);
+	}
 }


### PR DESCRIPTION
Adds support for invalid args in cron events by relaxing the strict typing and showing a warning on the listing and editing screens.

See https://wordpress.org/support/topic/your-site-is-experiencing-a-technical-issue-due-to-wp-crontrol/.