### PR TITLE
Add crontrol_manage_cap filter for the required capability

### DIFF
--- a/src/Context/WordPressUserContext.php
+++ b/src/Context/WordPressUserContext.php
@@ -11,8 +11,8 @@ namespace Crontrol\Context;
  * UserContext implementation that checks WordPress user capabilities.
  *
  * This is the production implementation that maps to WordPress capabilities.
- * Currently uses edit_files for PHP cron events and manage_options for
- * URL and standard cron events. More granular capabilities can be added later.
+ * Currently uses edit_files for PHP cron events and the filterable manage cap
+ * (default: manage_options) for URL and standard cron events.
  */
 class WordPressUserContext implements UserContext {
 	#[\Override]
@@ -32,46 +32,46 @@ class WordPressUserContext implements UserContext {
 
 	#[\Override]
 	public function can_run_php_cron_events(): bool {
-		return current_user_can( 'manage_options' );
+		return current_user_can( \Crontrol\get_manage_cap() );
 	}
 
 	#[\Override]
 	public function can_create_url_cron_events(): bool {
-		return current_user_can( 'manage_options' );
+		return current_user_can( \Crontrol\get_manage_cap() );
 	}
 
 	#[\Override]
 	public function can_edit_url_cron_events(): bool {
-		return current_user_can( 'manage_options' );
+		return current_user_can( \Crontrol\get_manage_cap() );
 	}
 
 	#[\Override]
 	public function can_delete_url_cron_events(): bool {
-		return current_user_can( 'manage_options' );
+		return current_user_can( \Crontrol\get_manage_cap() );
 	}
 
 	#[\Override]
 	public function can_run_url_cron_events(): bool {
-		return current_user_can( 'manage_options' );
+		return current_user_can( \Crontrol\get_manage_cap() );
 	}
 
 	#[\Override]
 	public function can_create_standard_cron_events(): bool {
-		return current_user_can( 'manage_options' );
+		return current_user_can( \Crontrol\get_manage_cap() );
 	}
 
 	#[\Override]
 	public function can_edit_standard_cron_events(): bool {
-		return current_user_can( 'manage_options' );
+		return current_user_can( \Crontrol\get_manage_cap() );
 	}
 
 	#[\Override]
 	public function can_delete_standard_cron_events(): bool {
-		return current_user_can( 'manage_options' );
+		return current_user_can( \Crontrol\get_manage_cap() );
 	}
 
 	#[\Override]
 	public function can_run_standard_cron_events(): bool {
-		return current_user_can( 'manage_options' );
+		return current_user_can( \Crontrol\get_manage_cap() );
 	}
 }

--- a/src/bootstrap.php
+++ b/src/bootstrap.php
@@ -167,7 +167,7 @@ function pauser() {
  */
 function action_handle_posts() {
 	if ( isset( $_POST['crontrol_action'] ) && ( 'new_cron' === $_POST['crontrol_action'] ) ) {
-		if ( ! current_user_can( 'manage_options' ) ) {
+		if ( ! current_user_can( get_manage_cap() ) ) {
 			wp_die( esc_html__( 'You are not allowed to add new cron events.', 'wp-crontrol' ), 403 );
 		}
 		check_admin_referer( 'crontrol-new-cron' );
@@ -359,7 +359,7 @@ function action_handle_posts() {
 		exit;
 
 	} elseif ( isset( $_POST['crontrol_action'] ) && ( 'edit_cron' === $_POST['crontrol_action'] ) ) {
-		if ( ! current_user_can( 'manage_options' ) ) {
+		if ( ! current_user_can( get_manage_cap() ) ) {
 			wp_die( esc_html__( 'You are not allowed to edit cron events.', 'wp-crontrol' ), 403 );
 		}
 
@@ -447,7 +447,7 @@ function action_handle_posts() {
 		exit;
 
 	} elseif ( isset( $_POST['crontrol_action'] ) && ( 'edit_url_cron' === $_POST['crontrol_action'] ) ) {
-		if ( ! current_user_can( 'manage_options' ) ) {
+		if ( ! current_user_can( get_manage_cap() ) ) {
 			wp_die( esc_html__( 'You are not allowed to edit cron events.', 'wp-crontrol' ), 403 );
 		}
 
@@ -612,7 +612,7 @@ function action_handle_posts() {
 		exit;
 
 	} elseif ( isset( $_POST['crontrol_new_schedule'] ) ) {
-		if ( ! current_user_can( 'manage_options' ) ) {
+		if ( ! current_user_can( get_manage_cap() ) ) {
 			wp_die( esc_html__( 'You are not allowed to add new cron schedules.', 'wp-crontrol' ), 403 );
 		}
 		check_admin_referer( 'crontrol-new-schedule' );
@@ -644,7 +644,7 @@ function action_handle_posts() {
 		exit;
 
 	} elseif ( isset( $_GET['crontrol_action'] ) && 'delete-schedule' === $_GET['crontrol_action'] ) {
-		if ( ! current_user_can( 'manage_options' ) ) {
+		if ( ! current_user_can( get_manage_cap() ) ) {
 			wp_die( esc_html__( 'You are not allowed to delete cron schedules.', 'wp-crontrol' ), 403 );
 		}
 		$schedule = wp_unslash( $_GET['crontrol_id'] );
@@ -659,7 +659,7 @@ function action_handle_posts() {
 		exit;
 
 	} elseif ( ( isset( $_POST['action'] ) && 'crontrol_delete_crons' === $_POST['action'] ) || ( isset( $_POST['action2'] ) && 'crontrol_delete_crons' === $_POST['action2'] ) ) {
-		if ( ! current_user_can( 'manage_options' ) ) {
+		if ( ! current_user_can( get_manage_cap() ) ) {
 			wp_die( esc_html__( 'You are not allowed to delete cron events.', 'wp-crontrol' ), 403 );
 		}
 		check_admin_referer( 'bulk-crontrol-events' );
@@ -702,7 +702,7 @@ function action_handle_posts() {
 		exit;
 
 	} elseif ( isset( $_GET['crontrol_action'] ) && 'delete-cron' === $_GET['crontrol_action'] ) {
-		if ( ! current_user_can( 'manage_options' ) ) {
+		if ( ! current_user_can( get_manage_cap() ) ) {
 			wp_die( esc_html__( 'You are not allowed to delete cron events.', 'wp-crontrol' ), 403 );
 		}
 		$hook         = wp_unslash( $_GET['crontrol_id'] );
@@ -748,7 +748,7 @@ function action_handle_posts() {
 		exit;
 
 	} elseif ( isset( $_GET['crontrol_action'] ) && 'delete-hook' === $_GET['crontrol_action'] ) {
-		if ( ! current_user_can( 'manage_options' ) ) {
+		if ( ! current_user_can( get_manage_cap() ) ) {
 			wp_die( esc_html__( 'You are not allowed to delete cron events.', 'wp-crontrol' ), 403 );
 		}
 		$hook    = wp_unslash( $_GET['crontrol_id'] );
@@ -799,7 +799,7 @@ function action_handle_posts() {
 			exit;
 		}
 	} elseif ( isset( $_GET['crontrol_action'] ) && 'run-cron' === $_GET['crontrol_action'] ) {
-		if ( ! current_user_can( 'manage_options' ) ) {
+		if ( ! current_user_can( get_manage_cap() ) ) {
 			wp_die( esc_html__( 'You are not allowed to run cron events.', 'wp-crontrol' ), 403 );
 		}
 		$hook = wp_unslash( $_GET['crontrol_id'] );
@@ -843,7 +843,7 @@ function action_handle_posts() {
 		wp_safe_redirect( add_query_arg( $redirect, admin_url( 'tools.php' ) ) );
 		exit;
 	} elseif ( isset( $_GET['crontrol_action'] ) && 'pause-hook' === $_GET['crontrol_action'] ) {
-		if ( ! current_user_can( 'manage_options' ) ) {
+		if ( ! current_user_can( get_manage_cap() ) ) {
 			wp_die( esc_html__( 'You are not allowed to pause or resume cron events.', 'wp-crontrol' ), 403 );
 		}
 
@@ -890,7 +890,7 @@ function action_handle_posts() {
 		wp_safe_redirect( add_query_arg( $redirect, admin_url( 'tools.php' ) ) );
 		exit;
 	} elseif ( isset( $_GET['crontrol_action'] ) && 'resume-hook' === $_GET['crontrol_action'] ) {
-		if ( ! current_user_can( 'manage_options' ) ) {
+		if ( ! current_user_can( get_manage_cap() ) ) {
 			wp_die( esc_html__( 'You are not allowed to pause or resume cron events.', 'wp-crontrol' ), 403 );
 		}
 
@@ -1029,14 +1029,14 @@ function action_admin_menu() {
 	$tabs[] = add_options_page(
 		esc_html__( 'Cron Schedules', 'wp-crontrol' ),
 		esc_html__( 'Cron Schedules', 'wp-crontrol' ),
-		'manage_options',
+		get_manage_cap(),
 		'wp-crontrol-schedules',
 		__NAMESPACE__ . '\admin_options_page'
 	);
 	$tabs[] = add_management_page(
 		esc_html__( 'Cron Events', 'wp-crontrol' ),
 		esc_html__( 'Cron Events', 'wp-crontrol' ),
-		'manage_options',
+		get_manage_cap(),
 		'wp-crontrol',
 		__NAMESPACE__ . '\admin_manage_page'
 	);
@@ -2973,5 +2973,22 @@ function url_cron_events_enabled(): bool {
  * Returns whether URL cron events are enabled and can be edited by the current user.
  */
 function current_user_can_edit_url_cron_events(): bool {
-	return ( url_cron_events_enabled() && current_user_can( 'manage_options' ) );
+	return ( url_cron_events_enabled() && current_user_can( get_manage_cap() ) );
+}
+
+/**
+ * Returns the capability required to manage cron events and schedules.
+ *
+ * Defaults to `manage_options`. Use the `crontrol_manage_cap` filter to override this,
+ * for example to use `manage_network_options` on a multisite network.
+ *
+ * @return string The required capability.
+ */
+function get_manage_cap(): string {
+	/**
+	 * Filters the capability required to manage cron events and schedules.
+	 *
+	 * @param string $cap The required capability. Default 'manage_options'.
+	 */
+	return (string) apply_filters( 'crontrol_manage_cap', 'manage_options' );
 }


### PR DESCRIPTION
## Summary

Closes #157.

Adds a `crontrol_manage_cap` filter so site owners can override the capability required to access WP Crontrol, without needing to hack around the menu or hook into access checks manually.

The most common use case is multisite installs where `manage_options` is too permissive — standard site admins have it, but the site owner only wants network admins (who have `manage_network_options`) to see and use the plugin.

### Usage

```php
add_filter( 'crontrol_manage_cap', function( string $cap ): string {
    return 'manage_network_options';
} );
```

## Implementation

- Added `get_manage_cap()` helper function in `bootstrap.php` that applies the filter and defaults to `'manage_options'`
- Replaced all 13 hardcoded `'manage_options'` capability strings in `bootstrap.php` (action handlers + menu registration) with `get_manage_cap()`
- Updated `WordPressUserContext` to call `\Crontrol\get_manage_cap()` for the same consistency

The `edit_files` capability used for PHP cron events is unchanged — that one is tied to WordPress core's own "can this user edit PHP files" concept and is separate from the general management cap.

## Test plan

- [ ] Default behaviour unchanged — `manage_options` users can access everything as before
- [ ] With the filter returning `manage_network_options`, standard site admins can no longer see the Cron Events or Cron Schedules menu items
- [ ] With the filter returning `manage_network_options`, standard site admins get a `wp_die()` if they attempt to POST to any crontrol action directly