### PR TITLE
Disable view transitions in acceptance tests

### DIFF
--- a/tests/acceptance/utils/test-setup.ts
+++ b/tests/acceptance/utils/test-setup.ts
@@ -23,6 +23,16 @@ type CrontrolFixtures = {
 };
 
 export const test = base.extend<CrontrolFixtures>( {
+	page: async ( { page }, use ) => {
+		/*
+		 * WordPress 7.0 enables cross-document view transitions in the admin area, which
+		 * suspend rendering of the incoming document. Under a headless browser that never
+		 * resolves, so no frames get produced and Playwright's element stability check can
+		 * never settle. Core gates that CSS behind `prefers-reduced-motion: no-preference`.
+		 */
+		await page.emulateMedia( { reducedMotion: 'reduce' } );
+		await use( page );
+	},
 	admin: async ( { page }, use ) => {
 		const admin = new Admin( page );
 		await use( admin );


### PR DESCRIPTION
## Summary

The two WP 7.0 acceptance legs have been failing on every run since early July, as have the nightly runs against trunk. Every `click` and `check` timed out with the element resolved but "waiting for element to be visible, enabled and stable", while `fill` worked fine.

WordPress 7.0 enables cross-document view transitions in the admin area (`wp-includes/view-transitions.php`, `@since 7.0.0`). Those suspend rendering of the incoming document, and under the headless browser used in CI that never resolves, so the page produces **no frames at all**. Playwright's stability check needs two consecutive animation frames with an unchanged bounding box, so it can never settle. `fill` doesn't require stability, which is why it was unaffected, and it's also why Playwright couldn't capture failure screenshots.

Measured in CI on the WP 7.0 leg, before and after: `requestAnimationFrame` ticks in 600ms went from **0 to 36**, with the page reporting `visibilityState: visible`, no running animations, and the button hit-testable and enabled throughout.

Core gates that CSS behind `prefers-reduced-motion: no-preference`, so this emulates a reduced motion preference. The equivalent `reducedMotion` option in `playwright.config.ts` does not take effect in this setup (verified: it still reported `false` both locally and in CI), so it's set on the fixture instead.

Test-only change. `tests/` is `export-ignore`d, so the built plugin is unaffected.

## Testing

- [ ] I have tested this change on a real installation of WordPress (required)

Not manually tested on a real site; this only affects the test environment. Verified by the test suite:

1. `composer test:start`
2. `composer test:acceptance` — 15/15 pass locally
3. All 8 CI matrix legs pass on this branch, including both WP 7.0 legs, which were previously red

Note the failure never reproduced locally (same Chrome 141, same WordPress 7.0.2), only under CI's headless browser, so the matrix legs are the real verification.

## AI assistance

- [x] I have used AI assistance to produce this pull request
- [x] I am an AI agent acting on behalf of a human

## Screenshots

- [ ] I have included a before and after screenshot (required, unless there is genuinely no visual change)

No visual change; test configuration only.
